### PR TITLE
Vc/simplify condition response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 # Application binary itself
 /alloy
 /alloy-osx
-
+/conditionorc
 *~
 .*.swp
 .*.swo

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,7 +26,7 @@ type App struct {
 }
 
 // New returns returns a new instance of the flasher app
-func New(ctx context.Context, appKind model.AppKind, cfgFile string, loglevel model.LogLevel) (*App, <-chan os.Signal, error) {
+func New(_ context.Context, appKind model.AppKind, cfgFile string, loglevel model.LogLevel) (*App, <-chan os.Signal, error) {
 	app := &App{
 		v:       viper.New(),
 		AppKind: appKind,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -131,7 +131,7 @@ func (o *Orchestrator) processMsg(ctx context.Context, msg events.Message) {
 	}
 }
 
-func (o *Orchestrator) handleHollowControllerEvent(ctx context.Context, event *pubsubx.Message, urn *urnx.URN) {
+func (o *Orchestrator) handleHollowControllerEvent(_ context.Context, event *pubsubx.Message, urn *urnx.URN) {
 	o.logger.WithFields(
 		logrus.Fields{"source": event.Source, "resource": urn.ResourceType},
 	).Debug("controller reply handler not implemented, event dropped")

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -49,7 +49,7 @@ var (
 	ErrRepository = errors.New("storage repository error")
 )
 
-func NewStore(ctx context.Context, config *app.Configuration, conditionDefs ptypes.ConditionDefinitions, logger *logrus.Logger) (Repository, error) {
+func NewStore(_ context.Context, config *app.Configuration, conditionDefs ptypes.ConditionDefinitions, logger *logrus.Logger) (Repository, error) {
 	switch config.StoreKind {
 	case model.ServerserviceStore:
 		return newServerserviceStore(&config.ServerserviceOptions, conditionDefs, logger)

--- a/internal/store/serverservice.go
+++ b/internal/store/serverservice.go
@@ -53,7 +53,7 @@ func newServerserviceStore(config *app.ServerserviceOptions, conditionDefs ptype
 }
 
 // Ping tests the repository is available.
-func (s *Serverservice) Ping(ctx context.Context) error {
+func (s *Serverservice) Ping(_ context.Context) error {
 	// TODO: implement
 	return nil
 }

--- a/pkg/api/v1/client/client_test.go
+++ b/pkg/api/v1/client/client_test.go
@@ -158,13 +158,15 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 
 				return &v1types.ServerResponse{
 					StatusCode: 200,
-					Record: &v1types.ConditionResponse{
+					Records: &v1types.ConditionsResponse{
 						ServerID: serverID,
-						Condition: &ptypes.Condition{
-							Kind:       ptypes.FirmwareInstallOutofband,
-							State:      ptypes.Pending,
-							Status:     []byte(`{"hello":"world"}`),
-							Parameters: parameters,
+						Conditions: []*ptypes.Condition{
+							{
+								Kind:       ptypes.FirmwareInstallOutofband,
+								State:      ptypes.Pending,
+								Status:     []byte(`{"hello":"world"}`),
+								Parameters: parameters,
+							},
 						},
 					},
 				}

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -371,9 +371,15 @@ func (r *Routes) serverConditionGet(c *gin.Context) {
 		return
 	}
 
-	data := v1types.ConditionResponse{ServerID: serverID, Condition: found}
-
-	c.JSON(http.StatusOK, &v1types.ServerResponse{Record: &data})
+	c.JSON(http.StatusOK,
+		&v1types.ServerResponse{
+			Records: &v1types.ConditionsResponse{
+				ServerID: serverID,
+				Conditions: []*ptypes.Condition{
+					found,
+				},
+			},
+		})
 }
 
 func (r *Routes) publishCondition(ctx context.Context, serverID uuid.UUID, condition *ptypes.Condition) {

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -753,9 +753,11 @@ func TestServerConditionGet(t *testing.T) {
 				want := asJSONBytes(
 					t,
 					&v1types.ServerResponse{
-						Record: &v1types.ConditionResponse{
-							ServerID:  serverID,
-							Condition: condition,
+						Records: &v1types.ConditionsResponse{
+							ServerID: serverID,
+							Conditions: []*ptypes.Condition{
+								condition,
+							},
 						},
 					},
 				)

--- a/pkg/api/v1/types/types.go
+++ b/pkg/api/v1/types/types.go
@@ -9,17 +9,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// the Records field is allowed to be empty or have only one record.
 type ServerResponse struct {
 	StatusCode int                 `json:"statusCode,omitempty"`
 	Message    string              `json:"message,omitempty"`
-	Record     *ConditionResponse  `json:"record,omitempty"`
 	Records    *ConditionsResponse `json:"records,omitempty"`
-}
-
-// ConditionResponse is the response returned for a single condition request.
-type ConditionResponse struct {
-	ServerID  uuid.UUID         `json:"serverID,omitempty"`
-	Condition *ptypes.Condition `json:"condition,omitempty"`
 }
 
 // ConditionsResponse is the response returned for listing multiple conditions on a server.


### PR DESCRIPTION
#### What does this PR do
Here we simplify the data structures in use by `conditionorc` by removing the single condition-response field in the `ServerResponse` and updating the semantics of that field such that `ConditionsResponse` is used unconditionally, with its slice of `Conditions` allowed to be empty, have one condition, or have multiple.