### PR TITLE
Vc/metrics part1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.19
 
 require (
 	github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20190729070250-5ae5475bae5e
-	github.com/davecgh/go-spew v1.1.1
 	github.com/gin-gonic/gin v1.9.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.14.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
@@ -21,9 +21,12 @@ require (
 )
 
 require (
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.8.6 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/cockroachdb/cockroach-go/v2 v2.3.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ericlagergren/decimal v0.0.0-20221120152707-495c53812d05 // indirect
 	github.com/friendsofgo/errors v0.9.2 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
@@ -57,6 +60,7 @@ require (
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -66,6 +70,9 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.3.0 // indirect
+	github.com/prometheus/common v0.39.0 // indirect
+	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -604,7 +604,6 @@ github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -1708,6 +1707,7 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
+github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.42.0/go.mod h1:Pfqb/MLnnR2KK+0vchiaH39jXxvLMBk+3lnIGP4N7Vk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
@@ -2013,8 +2013,8 @@ go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
-go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
 go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,7 +25,7 @@ type App struct {
 	Logger *logrus.Logger
 }
 
-// New returns returns a new instance of the flasher app
+// New returns returns a new instance of the conditionorc app
 func New(_ context.Context, appKind model.AppKind, cfgFile string, loglevel model.LogLevel) (*App, <-chan os.Signal, error) {
 	app := &App{
 		v:       viper.New(),

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -45,7 +45,7 @@ type Configuration struct {
 	// EventsBrokerKind indicates the kind of event broker configuration to enable,
 	//
 	// Supported parameter value - nats
-	EventsBorkerKind model.EventBrokerKind `mapstructure:"events_broker_kind"`
+	EventsBrokerKind model.EventBrokerKind `mapstructure:"events_broker_kind"`
 
 	// NatsOptions defines the NATs events broker configuration parameters.
 	//
@@ -114,7 +114,7 @@ func (a *App) envVarOverrides() error {
 		return errors.Wrap(ErrConfig, "expected one or more condition definitions")
 	}
 
-	if a.Config.EventsBorkerKind == model.NatsEventBroker {
+	if a.Config.EventsBrokerKind == model.NatsEventBroker {
 		if err := a.envVarNatsOverrides(); err != nil {
 			return err
 		}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,56 @@
+// Package metrics exports some utility functions for handling prometheus metrics
+// from ConditionOrc
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	apiLatencySeconds    *prometheus.HistogramVec
+	dependencyErrorCount *prometheus.CounterVec
+)
+
+func init() {
+	dependencyErrorCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "conditionorc",
+			Subsystem: "depencencies",
+			Name:      "errors_total",
+			Help:      "a count of all errors attempting to reach conditionorc dependencies",
+		}, []string{
+			"dependency_name",
+		},
+	)
+	apiLatencySeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "conditionorc",
+			Subsystem: "api",
+			Name:      "latency_seconds",
+			Help:      "api latency measurements in seconds",
+			// XXX: will need to tune these buckets once we understand common behaviors better
+			// buckets between 25ms to 10 s
+			Buckets: []float64{0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0},
+		}, []string{
+			"endpoint",
+			"response_code",
+		},
+	)
+}
+
+// DependencyError provides a convenience method to hide some prometheus implementation
+// details.
+func DependencyError(name string) {
+	dependencyErrorCount.WithLabelValues(name).Inc()
+}
+
+// APICallEpilog observes the results and latency of an API call
+func APICallEpilog(start time.Time, endpoint string, response_code int) {
+	code := strconv.Itoa(response_code)
+	elapsed := time.Now().Sub(start).Seconds()
+	apiLatencySeconds.WithLabelValues(endpoint, code).Observe(elapsed)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,7 +19,7 @@ func init() {
 	dependencyErrorCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "conditionorc",
-			Subsystem: "depencencies",
+			Subsystem: "dependencies",
 			Name:      "errors_total",
 			Help:      "a count of all errors attempting to reach conditionorc dependencies",
 		}, []string{
@@ -49,8 +49,8 @@ func DependencyError(name string) {
 }
 
 // APICallEpilog observes the results and latency of an API call
-func APICallEpilog(start time.Time, endpoint string, response_code int) {
-	code := strconv.Itoa(response_code)
-	elapsed := time.Now().Sub(start).Seconds()
+func APICallEpilog(start time.Time, endpoint string, responseCode int) {
+	code := strconv.Itoa(responseCode)
+	elapsed := time.Since(start).Seconds()
 	apiLatencySeconds.WithLabelValues(endpoint, code).Observe(elapsed)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/metal-toolbox/conditionorc/pkg/api/v1/routes"
 	ptypes "github.com/metal-toolbox/conditionorc/pkg/types"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	ginlogrus "github.com/toorop/gin-logrus"
 	"go.hollow.sh/toolbox/events"
@@ -82,6 +83,8 @@ func New(opts ...Option) *http.Server {
 	g.Use(ginlogrus.Logger(s.logger), gin.Recovery())
 
 	g.GET("/healthz/readiness", s.ping)
+
+	g.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	options := []routes.Option{
 		routes.WithLogger(s.logger),

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -3,7 +3,8 @@ package store
 import "github.com/pkg/errors"
 
 var (
-	ErrServerNotFound    = errors.New("server not found")
-	ErrConditionExists   = errors.New("condition exists on server")
-	ErrConditionNotFound = errors.New("condition not found")
+	ErrServerNotFound     = errors.New("server not found")
+	ErrConditionExists    = errors.New("condition exists on server")
+	ErrConditionNotFound  = errors.New("condition not found")
+	ErrMalformedCondition = errors.New("condition data is invalid")
 )

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -27,110 +27,92 @@ func (r *Routes) conditionKindValid(kind ptypes.ConditionKind) bool {
 	return found != nil
 }
 
-func (r *Routes) serverConditionUpdate(c *gin.Context) {
+func (r *Routes) serverConditionUpdate(c *gin.Context) (int, *v1types.ServerResponse) {
 	// XXX: should "uuid" be "server-uuid" or something?
 	serverID, err := uuid.Parse(c.Param("uuid"))
 	if err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "invalid ConditionUpdate payload " + err.Error()},
-		)
 		// XXX: do we have any way to correlate an API request id through this stack?
 		r.logger.WithFields(logrus.Fields{
 			"serverID": c.Param("uuid"),
 		}).Info("bad serverID")
-		return
+
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid ConditionUpdate payload " + err.Error(),
+		}
 	}
 
 	kind := ptypes.ConditionKind(c.Param("conditionKind"))
 	if !r.conditionKindValid(kind) {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "unsupported condition kind: " + string(kind)},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"kind": kind,
 		}).Info("unsupported condition kind")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "unsupported condition kind: " + string(kind),
+		}
 	}
 
 	var conditionUpdate v1types.ConditionUpdate
 	if err = c.ShouldBindJSON(&conditionUpdate); err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "invalid ConditionUpdate payload " + err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"error": err,
 		}).Info("invalid ConditionUpdate")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid ConditionUpdate payload " + err.Error(),
+		}
 	}
 
 	if conditionUpdate.ResourceVersion == 0 {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "invalid ConditionUpdate payload: resourceVersion not set"},
-		)
 		r.logger.Info("resource version not set")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid ConditionUpdate payload: resourceVersion not set",
+		}
 	}
 
 	if conditionUpdate.State == "" || conditionUpdate.Status == nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "invalid ConditionUpdate payload: state and status attributes are expected"},
-		)
 		r.logger.Info("invalid state and status pair")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid ConditionUpdate payload: state and status attributes are expected",
+		}
 	}
 
 	// query existing condition
 	existing, err := r.repository.Get(c.Request.Context(), serverID, kind)
 	if err != nil {
-		c.JSON(
-			http.StatusServiceUnavailable, // HTTP 503 -- this should signal a retry from the client
-			&v1types.ServerResponse{Message: err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"error":    err,
 			"serverID": serverID.String(),
 			"kind":     kind,
 		}).Info("condition lookup failed")
-		return
+		return http.StatusServiceUnavailable, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
 	if existing == nil {
-		c.JSON(
-			http.StatusNotFound,
-			&v1types.ServerResponse{Message: "no existing condition found for update"},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"serverID": serverID.String(),
 			"kind":     kind,
 		}).Info("condition not found")
 
-		return
+		return http.StatusNotFound, &v1types.ServerResponse{
+			Message: "no existing condition found for update",
+		}
 	}
 
 	// nothing to update
-	// XXX: consider just doing the update unconditionally?
 	if existing.State == conditionUpdate.State && bytes.Equal(existing.Status, conditionUpdate.Status) {
-		c.JSON(http.StatusOK, &v1types.ServerResponse{Message: "no changes to be applied"})
-
-		return
+		return http.StatusOK, &v1types.ServerResponse{
+			Message: "no changes to be applied",
+		}
 	}
 
 	// merge update with existing
 	update, err := conditionUpdate.MergeExisting(existing)
 	if err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "invalid ConditionUpdate payload"},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"error":            err,
 			"incoming_state":   conditionUpdate.State,
@@ -139,15 +121,13 @@ func (r *Routes) serverConditionUpdate(c *gin.Context) {
 			"existing_version": existing.ResourceVersion,
 		}).Info("condition merge failed")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid ConditionUpdate payload",
+		}
 	}
 
 	// update
 	if err := r.repository.Update(c.Request.Context(), serverID, update); err != nil {
-		c.JSON(
-			http.StatusInternalServerError,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"error":             err,
 			"serverID":          serverID,
@@ -155,50 +135,46 @@ func (r *Routes) serverConditionUpdate(c *gin.Context) {
 			"condition_version": update.ResourceVersion,
 		}).Info("condition update failed")
 
-		return
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
-	c.JSON(http.StatusOK, &v1types.ServerResponse{Message: "condition updated"})
+	return http.StatusOK, &v1types.ServerResponse{Message: "condition updated"}
 }
 
-func (r *Routes) serverConditionCreate(c *gin.Context) {
+func (r *Routes) serverConditionCreate(c *gin.Context) (int, *v1types.ServerResponse) {
 	serverID, err := uuid.Parse(c.Param("uuid"))
 	if err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"serverID": c.Param("uuid"),
 		}).Info("bad serverID")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
 	kind := ptypes.ConditionKind(c.Param("conditionKind"))
 	if !r.conditionKindValid(kind) {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "unsupported condition kind: " + string(kind)},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"kind": kind,
 		}).Info("unsupported condition kind")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "unsupported condition kind: " + string(kind),
+		}
 	}
 
 	var conditionCreate v1types.ConditionCreate
 	if err = c.ShouldBindJSON(&conditionCreate); err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "invalid ConditionCreate payload: " + err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
-			"kind": kind,
-		}).Info("unsupported condition kind")
+			"error": err,
+		}).Info("invalid ConditionCreate payload")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid ConditionCreate payload: " + err.Error(),
+		}
 	}
 
 	condition := conditionCreate.NewCondition(kind)
@@ -206,43 +182,40 @@ func (r *Routes) serverConditionCreate(c *gin.Context) {
 	// check the condition doesn't already exist in an incomplete state
 	existing, err := r.repository.Get(c.Request.Context(), serverID, kind)
 	if err != nil && !errors.Is(err, store.ErrConditionNotFound) {
-		c.JSON(
-			http.StatusServiceUnavailable,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"error":    err,
 			"serverID": serverID.String(),
 			"kind":     kind,
 		}).Info("condition lookup failed")
 
-		return
+		return http.StatusServiceUnavailable, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
 	if existing != nil && !existing.IsComplete() {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "condition present in an incomplete state: " + string(existing.State)},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"serverID":    serverID.String(),
 			"conditionID": existing.ID.String(),
 			"kind":        kind,
 		}).Info("existing server condition found")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "condition present in an incomplete state: " + string(existing.State),
+		}
 	}
 
 	// purge the existing condition
 	if existing != nil {
 		err = r.repository.Delete(c.Request.Context(), serverID, kind)
 		if err != nil && !errors.Is(err, store.ErrConditionNotFound) {
-			c.JSON(
-				http.StatusInternalServerError,
-				&v1types.ServerResponse{Message: err.Error()},
-			)
+			r.logger.WithFields(logrus.Fields{
+				"error": err,
+			}).Info("unable to remove existing, finalized condition")
 
-			return
+			return http.StatusInternalServerError, &v1types.ServerResponse{
+				Message: err.Error(),
+			}
 		}
 	}
 
@@ -251,40 +224,44 @@ func (r *Routes) serverConditionCreate(c *gin.Context) {
 	// check if any condition with exclusive set is in incomplete states
 	if errEx := r.exclusiveNonFinalConditionExists(c.Request.Context(), serverID); errEx != nil {
 		if errors.Is(errEx, ErrConditionExclusive) {
-			c.JSON(
-				http.StatusBadRequest,
-				&v1types.ServerResponse{Message: errEx.Error()},
-			)
+			r.logger.WithFields(logrus.Fields{
+				"error": err,
+				// XXX: would be nice to have the id of the exclusive condition here too
+			}).Info("active, exclusive condition on this server")
 
-			return
+			return http.StatusBadRequest, &v1types.ServerResponse{
+				Message: errEx.Error(),
+			}
 		}
 
-		c.JSON(
-			http.StatusInternalServerError,
-			&v1types.ServerResponse{Message: errEx.Error()},
-		)
+		r.logger.WithFields(logrus.Fields{
+			"error": err,
+		}).Info("error checking for exclusive conditions")
 
-		return
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: errEx.Error(),
+		}
 	}
 
 	// Create the new condition
 	err = r.repository.Create(c.Request.Context(), serverID, condition)
 	if err != nil {
-		c.JSON(
-			http.StatusInternalServerError,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"error": err,
 		}).Info("condition create failed")
 
-		return
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
+	// XXX: this operation can't ignore errors
 	// publish the condition
 	r.publishCondition(c.Request.Context(), serverID, condition)
 
-	c.JSON(http.StatusOK, &v1types.ServerResponse{Message: "condition set"})
+	return http.StatusOK, &v1types.ServerResponse{
+		Message: "condition set",
+	}
 }
 
 func (r *Routes) exclusiveNonFinalConditionExists(ctx context.Context, serverID uuid.UUID) error {
@@ -322,140 +299,124 @@ func (r *Routes) exclusiveNonFinalConditionExists(ctx context.Context, serverID 
 	return nil
 }
 
-func (r *Routes) serverConditionDelete(c *gin.Context) {
+func (r *Routes) serverConditionDelete(c *gin.Context) (int, *v1types.ServerResponse) {
 	serverID, err := uuid.Parse(c.Param("uuid"))
 	if err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"serverID": c.Param("uuid"),
 		}).Info("bad serverID")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
 	kind := ptypes.ConditionKind(c.Param("conditionKind"))
 	if !r.conditionKindValid(kind) {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "unsupported condition kind: " + string(kind)},
-		)
 		r.logger.WithFields(logrus.Fields{
 			"kind": kind,
 		}).Info("unsupported condition kind")
 
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "unsupported condition kind: " + string(kind),
+		}
 	}
 
 	// TODO (vc): the repository Delete route should take a condition id
 	if err := r.repository.Delete(c.Request.Context(), serverID, kind); err != nil {
-		c.JSON(
-			http.StatusInternalServerError,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
+		r.logger.WithFields(logrus.Fields{
+			"serverID": serverID.String(),
+			"kind":     kind,
+			"error":    err,
+		}).Warn("unable to delete condition from repository")
 
-		return
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
-	c.JSON(http.StatusOK, &v1types.ServerResponse{Message: "condition deleted"})
+	return http.StatusOK, &v1types.ServerResponse{
+		Message: "condition deleted",
+	}
 }
 
-func (r *Routes) serverConditionList(c *gin.Context) {
+func (r *Routes) serverConditionList(c *gin.Context) (int, *v1types.ServerResponse) {
 	serverID, err := uuid.Parse(c.Param("uuid"))
 	if err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
-
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{Message: err.Error()}
 	}
 
+	// XXX: should this be condition_state in the gin Context?
 	state := ptypes.ConditionState(c.Param("conditionState"))
 	if state != "" && !ptypes.ConditionStateIsValid(state) {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "unsupported condition state: " + string(state)},
-		)
-
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "unsupported condition state: " + string(state),
+		}
 	}
 
 	found, err := r.repository.List(c.Request.Context(), serverID, state)
 	if err != nil {
-		c.JSON(
-			http.StatusInternalServerError,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
-
-		return
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
 	if len(found) == 0 {
-		c.JSON(http.StatusNotFound, &v1types.ServerResponse{Message: "no conditions in given state found on server"})
-
-		return
+		return http.StatusNotFound, &v1types.ServerResponse{
+			Message: "no conditions in given state found on server",
+		}
 	}
 
-	data := v1types.ConditionsResponse{ServerID: serverID, Conditions: found}
-
-	c.JSON(http.StatusOK, &v1types.ServerResponse{Records: &data})
+	return http.StatusOK, &v1types.ServerResponse{
+		Records: &v1types.ConditionsResponse{
+			ServerID:   serverID,
+			Conditions: found,
+		},
+	}
 }
 
-func (r *Routes) serverConditionGet(c *gin.Context) {
+func (r *Routes) serverConditionGet(c *gin.Context) (int, *v1types.ServerResponse) {
 	serverID, err := uuid.Parse(c.Param("uuid"))
 	if err != nil {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
-
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
 	kind := ptypes.ConditionKind(c.Param("conditionKind"))
 	if !r.conditionKindValid(kind) {
-		c.JSON(
-			http.StatusBadRequest,
-			&v1types.ServerResponse{Message: "unsupported condition kind: " + string(kind)},
-		)
-
-		return
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "unsupported condition kind: " + string(kind),
+		}
 	}
 
 	found, err := r.repository.Get(c.Request.Context(), serverID, kind)
 	if err != nil {
 		if errors.Is(err, store.ErrConditionNotFound) {
-			c.JSON(http.StatusNotFound, &v1types.ServerResponse{Message: "conditionKind not found on server"})
-
-			return
+			return http.StatusNotFound, &v1types.ServerResponse{
+				Message: "conditionKind not found on server",
+			}
 		}
 
-		c.JSON(
-			http.StatusServiceUnavailable,
-			&v1types.ServerResponse{Message: err.Error()},
-		)
-
-		return
+		return http.StatusServiceUnavailable, &v1types.ServerResponse{
+			Message: err.Error(),
+		}
 	}
 
 	if found == nil {
-		c.JSON(http.StatusNotFound, &v1types.ServerResponse{Message: "conditionKind not found on server"})
-
-		return
+		return http.StatusNotFound, &v1types.ServerResponse{
+			Message: "conditionKind not found on server",
+		}
 	}
 
-	c.JSON(http.StatusOK,
-		&v1types.ServerResponse{
-			Records: &v1types.ConditionsResponse{
-				ServerID: serverID,
-				Conditions: []*ptypes.Condition{
-					found,
-				},
+	return http.StatusOK, &v1types.ServerResponse{
+		Records: &v1types.ConditionsResponse{
+			ServerID: serverID,
+			Conditions: []*ptypes.Condition{
+				found,
 			},
-		})
+		},
+	}
 }
 
 func (r *Routes) publishCondition(ctx context.Context, serverID uuid.UUID, condition *ptypes.Condition) {

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -322,7 +322,6 @@ func (r *Routes) serverConditionDelete(c *gin.Context) (int, *v1types.ServerResp
 		}
 	}
 
-	// TODO (vc): the repository Delete route should take a condition id
 	if err := r.repository.Delete(c.Request.Context(), serverID, kind); err != nil {
 		r.logger.WithFields(logrus.Fields{
 			"serverID": serverID.String(),

--- a/pkg/api/v1/routes/routes.go
+++ b/pkg/api/v1/routes/routes.go
@@ -2,9 +2,12 @@ package routes
 
 import (
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/metal-toolbox/conditionorc/internal/metrics"
 	"github.com/metal-toolbox/conditionorc/internal/store"
+	v1types "github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
 	ptypes "github.com/metal-toolbox/conditionorc/pkg/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -63,6 +66,22 @@ func WithConditionDefinitions(defs ptypes.ConditionDefinitions) Option {
 	}
 }
 
+// apiHandler is a function that performs real work for the ConditionOrc API
+type apiHandler func(c *gin.Context) (int, *v1types.ServerResponse)
+
+// wrapAPICall wraps a conditionorc routine that does work with some prometheus
+// metrics collection and returns a gin.HandlerFunc so the middleware can execute
+// directly
+func wrapAPICall(fn apiHandler) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		start := time.Now()
+		endpoint := ctx.FullPath()
+		response_code, obj := fn(ctx)
+		ctx.JSON(response_code, obj)
+		metrics.APICallEpilog(start, endpoint, response_code)
+	}
+}
+
 // NewRoutes returns a new conditionorc API routes with handlers registered.
 func NewRoutes(options ...Option) (*Routes, error) {
 	routes := &Routes{}
@@ -92,21 +111,21 @@ func (r *Routes) Routes(g *gin.RouterGroup) {
 		// /servers/:uuid/state/:conditionState
 		serverCondition := servers.Group("/state")
 
-		serverCondition.GET("/:conditionState", r.serverConditionList)
+		serverCondition.GET("/:conditionState", wrapAPICall(r.serverConditionList))
 
 		// /servers/:uuid/condition/:conditionKind
 		serverConditionBySlug := servers.Group("/condition")
 
 		// List condition on a server.
-		serverConditionBySlug.GET("/:conditionKind", r.serverConditionGet)
+		serverConditionBySlug.GET("/:conditionKind", wrapAPICall(r.serverConditionGet))
 
 		// Create a condition on a server.
-		serverConditionBySlug.POST("/:conditionKind", r.serverConditionCreate)
+		serverConditionBySlug.POST("/:conditionKind", wrapAPICall(r.serverConditionCreate))
 
 		// Update an existing condition attributes on a server.
-		serverConditionBySlug.PUT("/:conditionKind", r.serverConditionUpdate)
+		serverConditionBySlug.PUT("/:conditionKind", wrapAPICall(r.serverConditionUpdate))
 
 		// Remove a condition from a server.
-		serverConditionBySlug.DELETE("/:conditionKind", r.serverConditionDelete)
+		serverConditionBySlug.DELETE("/:conditionKind", wrapAPICall(r.serverConditionDelete))
 	}
 }

--- a/pkg/api/v1/routes/routes.go
+++ b/pkg/api/v1/routes/routes.go
@@ -76,9 +76,9 @@ func wrapAPICall(fn apiHandler) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		start := time.Now()
 		endpoint := ctx.FullPath()
-		response_code, obj := fn(ctx)
-		ctx.JSON(response_code, obj)
-		metrics.APICallEpilog(start, endpoint, response_code)
+		responseCode, obj := fn(ctx)
+		ctx.JSON(responseCode, obj)
+		metrics.APICallEpilog(start, endpoint, responseCode)
 	}
 }
 


### PR DESCRIPTION
#### What does this PR do
Add prometheus metrics to the project and use them to instrument errors in reaching NATS and ServerService. Also observe and report latency metrics for the ConditionOrc API.

The prometheus scraper is managed by the same gin web server that hosts the API, so no need to add additional configuration.
