### PR TITLE
rename conditionKind

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -173,6 +173,14 @@ func (a *App) envVarNatsOverrides() error {
 		return errors.New("missing parameter: nats.url")
 	}
 
+	if a.v.GetString("nats.publisherSubjectPrefix") != "" {
+		a.Config.NatsOptions.PublisherSubjectPrefix = a.v.GetString("nats.publisherSubjectPrefix")
+	}
+
+	if a.Config.NatsOptions.PublisherSubjectPrefix == "" {
+		return errors.New("missing parameter: nats.publisherSubjectPrefix")
+	}
+
 	if a.v.GetString("nats.stream.user") != "" {
 		a.Config.NatsOptions.StreamUser = a.v.GetString("nats.stream.user")
 	}
@@ -187,6 +195,10 @@ func (a *App) envVarNatsOverrides() error {
 
 	if a.v.GetString("nats.stream.name") != "" {
 		a.Config.NatsOptions.Stream.Name = a.v.GetString("nats.stream.name")
+	}
+
+	if a.v.GetDuration("nats.connect.timeout") != 0 {
+		a.Config.NatsOptions.ConnectTimeout = a.v.GetDuration("nats.connect.timeout")
 	}
 
 	if a.Config.NatsOptions.ConnectTimeout == 0 {

--- a/pkg/api/v1/client/client_test.go
+++ b/pkg/api/v1/client/client_test.go
@@ -76,7 +76,7 @@ func newTester(t *testing.T, enableAuth bool, authToken string) *integrationTest
 		server.WithStore(repository),
 		server.WithConditionDefinitions(
 			[]*ptypes.ConditionDefinition{
-				{Kind: ptypes.FirmwareInstallOutofband},
+				{Kind: ptypes.FirmwareInstall},
 			},
 		),
 	}
@@ -129,7 +129,7 @@ func newTester(t *testing.T, enableAuth bool, authToken string) *integrationTest
 	return tester
 }
 
-// Firmware holds parameters for a firmware install and is part of FirmwareInstallOutofbandParameters.
+// Firmware holds parameters for a firmware install and is part of FirmwareInstallParameters.
 //
 // defined here for tests, this will be made available in a shared package at some point.
 type Firmware struct {
@@ -146,7 +146,7 @@ type Firmware struct {
 // firmwareInstallParameters define firmwareInstall condition parameters.
 //
 // defined here for tests, this will be made available in a shared package at some point.
-type FirmwareInstallOutofbandParameters struct {
+type FirmwareInstallParameters struct {
 	InventoryAfterUpdate bool        `json:"inventoryAfterUpdate,omitempty"`
 	ForceInstall         bool        `json:"forceInstall,omitempty"`
 	FirmwareSetID        string      `json:"firmwareSetID,omitempty"`
@@ -187,7 +187,7 @@ func TestIntegration_AuthToken(t *testing.T) {
 	}{
 		{
 			"invalid auth token returns 401",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			newTester(t, true, "asdf"),
 			// mock repository
 			nil,
@@ -201,11 +201,11 @@ func TestIntegration_AuthToken(t *testing.T) {
 		},
 		{
 			"valid auth token works",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			newTester(t, true, testAuthToken(t)),
 			// mock repository
 			func(r *store.MockRepository) {
-				parameters, err := json.Marshal(&FirmwareInstallOutofbandParameters{
+				parameters, err := json.Marshal(&FirmwareInstallParameters{
 					InventoryAfterUpdate: true,
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
@@ -220,11 +220,11 @@ func TestIntegration_AuthToken(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(
 						&ptypes.Condition{
-							Kind:       ptypes.FirmwareInstallOutofband,
+							Kind:       ptypes.FirmwareInstall,
 							State:      ptypes.Pending,
 							Status:     []byte(`{"hello":"world"}`),
 							Parameters: parameters,
@@ -233,7 +233,7 @@ func TestIntegration_AuthToken(t *testing.T) {
 					Times(1)
 			},
 			func() *v1types.ServerResponse {
-				parameters, err := json.Marshal(&FirmwareInstallOutofbandParameters{
+				parameters, err := json.Marshal(&FirmwareInstallParameters{
 					InventoryAfterUpdate: true,
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
@@ -249,7 +249,7 @@ func TestIntegration_AuthToken(t *testing.T) {
 						ServerID: serverID,
 						Conditions: []*ptypes.Condition{
 							{
-								Kind:       ptypes.FirmwareInstallOutofband,
+								Kind:       ptypes.FirmwareInstall,
 								State:      ptypes.Pending,
 								Status:     []byte(`{"hello":"world"}`),
 								Parameters: parameters,
@@ -304,10 +304,10 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 	}{
 		{
 			"valid response",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			// mock repository
 			func(r *store.MockRepository) {
-				parameters, err := json.Marshal(&FirmwareInstallOutofbandParameters{
+				parameters, err := json.Marshal(&FirmwareInstallParameters{
 					InventoryAfterUpdate: true,
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
@@ -322,11 +322,11 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(
 						&ptypes.Condition{
-							Kind:       ptypes.FirmwareInstallOutofband,
+							Kind:       ptypes.FirmwareInstall,
 							State:      ptypes.Pending,
 							Status:     []byte(`{"hello":"world"}`),
 							Parameters: parameters,
@@ -335,7 +335,7 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 					Times(1)
 			},
 			func() *v1types.ServerResponse {
-				parameters, err := json.Marshal(&FirmwareInstallOutofbandParameters{
+				parameters, err := json.Marshal(&FirmwareInstallParameters{
 					InventoryAfterUpdate: true,
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
@@ -351,7 +351,7 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 						ServerID: serverID,
 						Conditions: []*ptypes.Condition{
 							{
-								Kind:       ptypes.FirmwareInstallOutofband,
+								Kind:       ptypes.FirmwareInstall,
 								State:      ptypes.Pending,
 								Status:     []byte(`{"hello":"world"}`),
 								Parameters: parameters,
@@ -364,7 +364,7 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 		},
 		{
 			"404 response",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			// mock repository
 			func(r *store.MockRepository) {
 				// lookup existing condition
@@ -372,7 +372,7 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(
 						nil,
@@ -446,7 +446,7 @@ func TestIntegration_ConditionsList(t *testing.T) {
 			ptypes.Pending,
 			// mock repository
 			func(r *store.MockRepository) {
-				parameters, err := json.Marshal(&FirmwareInstallOutofbandParameters{
+				parameters, err := json.Marshal(&FirmwareInstallParameters{
 					InventoryAfterUpdate: true,
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
@@ -466,7 +466,7 @@ func TestIntegration_ConditionsList(t *testing.T) {
 					Return(
 						[]*ptypes.Condition{
 							{
-								Kind:       ptypes.FirmwareInstallOutofband,
+								Kind:       ptypes.FirmwareInstall,
 								State:      ptypes.Pending,
 								Status:     []byte(`{"hello":"world"}`),
 								Parameters: parameters,
@@ -482,7 +482,7 @@ func TestIntegration_ConditionsList(t *testing.T) {
 					Times(1)
 			},
 			func() *v1types.ServerResponse {
-				parameters, err := json.Marshal(&FirmwareInstallOutofbandParameters{
+				parameters, err := json.Marshal(&FirmwareInstallParameters{
 					InventoryAfterUpdate: true,
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
@@ -498,7 +498,7 @@ func TestIntegration_ConditionsList(t *testing.T) {
 						ServerID: serverID,
 						Conditions: []*ptypes.Condition{
 							{
-								Kind:       ptypes.FirmwareInstallOutofband,
+								Kind:       ptypes.FirmwareInstall,
 								State:      ptypes.Pending,
 								Status:     []byte(`{"hello":"world"}`),
 								Parameters: parameters,
@@ -597,7 +597,7 @@ func TestIntegration_ConditionsCreate(t *testing.T) {
 	}{
 		{
 			"valid payload sent",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			v1types.ConditionCreate{Parameters: []byte(`{"hello":"world"}`)},
 			// mock repository
 			func(r *store.MockRepository) {
@@ -605,7 +605,7 @@ func TestIntegration_ConditionsCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(
 						nil,
@@ -630,7 +630,7 @@ func TestIntegration_ConditionsCreate(t *testing.T) {
 					).
 					DoAndReturn(func(_ context.Context, _ uuid.UUID, c *ptypes.Condition) error {
 						assert.Equal(t, ptypes.ConditionStructVersion, c.Version, "condition version mismatch")
-						assert.Equal(t, ptypes.FirmwareInstallOutofband, c.Kind, "condition kind mismatch")
+						assert.Equal(t, ptypes.FirmwareInstall, c.Kind, "condition kind mismatch")
 						assert.Equal(t, json.RawMessage(`{"hello":"world"}`), c.Parameters, "condition parameters mismatch")
 						assert.Equal(t, ptypes.Pending, c.State, "condition state mismatch")
 						return nil
@@ -647,7 +647,7 @@ func TestIntegration_ConditionsCreate(t *testing.T) {
 		},
 		{
 			"400 response",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			v1types.ConditionCreate{Parameters: []byte(`{"hello":"world"}`)},
 			// mock repository
 			func(r *store.MockRepository) {
@@ -656,11 +656,11 @@ func TestIntegration_ConditionsCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(
 						&ptypes.Condition{
-							Kind:  ptypes.FirmwareInstallOutofband,
+							Kind:  ptypes.FirmwareInstall,
 							State: ptypes.Active,
 						},
 						nil).
@@ -719,7 +719,7 @@ func TestIntegration_ConditionsUpdate(t *testing.T) {
 	}{
 		{
 			"valid payload sent",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			v1types.ConditionUpdate{
 				State:           ptypes.Active,
 				Status:          []byte(`{"hello":"world"}`),
@@ -733,10 +733,10 @@ func TestIntegration_ConditionsUpdate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(&ptypes.Condition{ // condition present
-						Kind:            ptypes.FirmwareInstallOutofband,
+						Kind:            ptypes.FirmwareInstall,
 						State:           ptypes.Pending,
 						Status:          []byte(`{"hello":"world"}`),
 						ResourceVersion: 1,
@@ -762,7 +762,7 @@ func TestIntegration_ConditionsUpdate(t *testing.T) {
 		},
 		{
 			"404 response",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			v1types.ConditionUpdate{
 				State:           ptypes.Active,
 				Status:          []byte(`{"hello":"world"}`),
@@ -776,7 +776,7 @@ func TestIntegration_ConditionsUpdate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil, nil).
 					Times(1)
@@ -842,14 +842,14 @@ func TestIntegration_ConditionsDelete(t *testing.T) {
 	}{
 		{
 			"valid response",
-			ptypes.FirmwareInstallOutofband,
+			ptypes.FirmwareInstall,
 			// mock repository
 			func(r *store.MockRepository) {
 				r.EXPECT().
 					Delete(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil).
 					Times(1)

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -341,7 +341,7 @@ func (r *Routes) publishCondition(ctx context.Context, serverID uuid.UUID, facil
 		panic("unable to marshal a condition" + err.Error())
 	}
 
-	subject := fmt.Sprintf("com.hollow.sh.controllers.commands.%s.servers.firmware.outofband", facilityCode)
+	subject := fmt.Sprintf("com.hollow.sh.controllers.commands.%s.servers.%s", facilityCode, condition.Kind)
 	if err := r.streamBroker.Publish(
 		otelCtx,
 		subject,

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -34,7 +34,7 @@ func mockserver(t *testing.T, logger *logrus.Logger, repository store.Repository
 		WithStore(repository),
 		WithConditionDefinitions(
 			[]*ptypes.ConditionDefinition{
-				{Kind: ptypes.FirmwareInstallOutofband},
+				{Kind: ptypes.FirmwareInstall},
 			},
 		),
 	}
@@ -166,7 +166,7 @@ func TestServerConditionUpdate(t *testing.T) {
 			"invalid server condition update payload returns error",
 			nil,
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPut, url, bytes.NewReader(payloadInvalid))
 				if err != nil {
 					t.Fatal(err)
@@ -184,7 +184,7 @@ func TestServerConditionUpdate(t *testing.T) {
 			"update with no state returns an error",
 			nil,
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPut, url, bytes.NewReader(updateNoState))
 				if err != nil {
 					t.Fatal(err)
@@ -202,7 +202,7 @@ func TestServerConditionUpdate(t *testing.T) {
 			"update with no status returns an error",
 			nil,
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPut, url, bytes.NewReader(updateNoStatus))
 				if err != nil {
 					t.Fatal(err)
@@ -226,13 +226,13 @@ func TestServerConditionUpdate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil, nil).
 					Times(1)
 			},
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPut, url, bytes.NewReader(payloadValid))
 				if err != nil {
 					t.Fatal(err)
@@ -254,11 +254,11 @@ func TestServerConditionUpdate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(&ptypes.Condition{ // condition present
 						ID:              updateValid.ConditionID,
-						Kind:            ptypes.FirmwareInstallOutofband,
+						Kind:            ptypes.FirmwareInstall,
 						State:           updateValid.State,
 						Status:          updateValid.Status,
 						ResourceVersion: updateValid.ResourceVersion,
@@ -275,7 +275,7 @@ func TestServerConditionUpdate(t *testing.T) {
 					Times(1)
 			},
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPut, url, bytes.NewReader(payloadValid))
 				if err != nil {
 					t.Fatal(err)
@@ -363,7 +363,7 @@ func TestServerConditionCreate(t *testing.T) {
 			"invalid server condition payload returns error",
 			nil,
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, url, bytes.NewReader([]byte(``)))
 				if err != nil {
 					t.Fatal(err)
@@ -385,7 +385,7 @@ func TestServerConditionCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil, nil). // no condition exists
 					Times(1)
@@ -417,7 +417,7 @@ func TestServerConditionCreate(t *testing.T) {
 					t.Error()
 				}
 
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, url, bytes.NewReader(payload))
 				if err != nil {
 					t.Fatal(err)
@@ -441,7 +441,7 @@ func TestServerConditionCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil, nil). // no condition exists
 					Times(1)
@@ -476,7 +476,7 @@ func TestServerConditionCreate(t *testing.T) {
 					).
 					DoAndReturn(func(_ context.Context, _ uuid.UUID, c *ptypes.Condition) error {
 						assert.Equal(t, ptypes.ConditionStructVersion, c.Version, "condition version mismatch")
-						assert.Equal(t, ptypes.FirmwareInstallOutofband, c.Kind, "condition kind mismatch")
+						assert.Equal(t, ptypes.FirmwareInstall, c.Kind, "condition kind mismatch")
 						assert.Equal(t, json.RawMessage(parametersJSON), c.Parameters, "condition parameters mismatch")
 						assert.Equal(t, ptypes.Pending, c.State, "condition state mismatch")
 						return nil
@@ -489,7 +489,7 @@ func TestServerConditionCreate(t *testing.T) {
 					t.Error()
 				}
 
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, url, bytes.NewReader(payload))
 				if err != nil {
 					t.Fatal(err)
@@ -511,7 +511,7 @@ func TestServerConditionCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil, nil). // no condition exists
 					Times(1)
@@ -558,7 +558,7 @@ func TestServerConditionCreate(t *testing.T) {
 					t.Error(err)
 				}
 
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, url, bytes.NewReader(payload))
 				if err != nil {
 					t.Fatal(err)
@@ -585,10 +585,10 @@ func TestServerConditionCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(&ptypes.Condition{
-						Kind:  ptypes.FirmwareInstallOutofband,
+						Kind:  ptypes.FirmwareInstall,
 						State: ptypes.Succeeded,
 					}, nil). // no condition exists
 					Times(1)
@@ -606,7 +606,7 @@ func TestServerConditionCreate(t *testing.T) {
 					Delete(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil).
 					Times(1)
@@ -632,7 +632,7 @@ func TestServerConditionCreate(t *testing.T) {
 					).
 					DoAndReturn(func(_ context.Context, _ uuid.UUID, c *ptypes.Condition) error {
 						assert.Equal(t, ptypes.ConditionStructVersion, c.Version, "condition version mismatch")
-						assert.Equal(t, ptypes.FirmwareInstallOutofband, c.Kind, "condition kind mismatch")
+						assert.Equal(t, ptypes.FirmwareInstall, c.Kind, "condition kind mismatch")
 						assert.Equal(t, json.RawMessage(parametersJSON), c.Parameters, "condition parameters mismatch")
 						assert.Equal(t, ptypes.Pending, c.State, "condition state mismatch")
 						return nil
@@ -645,7 +645,7 @@ func TestServerConditionCreate(t *testing.T) {
 					t.Error()
 				}
 
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, url, bytes.NewReader(payload))
 				if err != nil {
 					t.Fatal(err)
@@ -668,17 +668,17 @@ func TestServerConditionCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(&ptypes.Condition{ // condition present
-						Kind:       ptypes.FirmwareInstallOutofband,
+						Kind:       ptypes.FirmwareInstall,
 						State:      ptypes.Pending,
 						Parameters: []byte(`{"hello":"world"}`),
 					}, nil).
 					Times(1)
 			},
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, url, bytes.NewReader([]byte(`{"hello":"world"}`)))
 				if err != nil {
 					t.Fatal(err)
@@ -700,7 +700,7 @@ func TestServerConditionCreate(t *testing.T) {
 					Get(
 						gomock.Any(),
 						gomock.Eq(serverID),
-						gomock.Eq(ptypes.FirmwareInstallOutofband),
+						gomock.Eq(ptypes.FirmwareInstall),
 					).
 					Return(nil, nil).
 					Times(1)
@@ -721,7 +721,7 @@ func TestServerConditionCreate(t *testing.T) {
 					Times(1)
 			},
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, url, bytes.NewReader([]byte(`{"hello":"world"}`)))
 				if err != nil {
 					t.Fatal(err)
@@ -875,7 +875,7 @@ func TestServerConditionList(t *testing.T) {
 func TestServerConditionGet(t *testing.T) {
 	serverID := uuid.New()
 	condition := &ptypes.Condition{
-		Kind:       ptypes.FirmwareInstallOutofband,
+		Kind:       ptypes.FirmwareInstall,
 		Parameters: json.RawMessage{},
 	}
 
@@ -935,12 +935,12 @@ func TestServerConditionGet(t *testing.T) {
 			// mock repository
 			func(r *store.MockRepository) {
 				r.EXPECT().
-					Get(gomock.Any(), gomock.Eq(serverID), gomock.Eq(ptypes.FirmwareInstallOutofband)).
+					Get(gomock.Any(), gomock.Eq(serverID), gomock.Eq(ptypes.FirmwareInstall)).
 					Times(1).
 					Return(condition, nil)
 			},
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, url, http.NoBody)
 				if err != nil {
@@ -1042,12 +1042,12 @@ func TestServerConditionDelete(t *testing.T) {
 			// mock repository
 			func(r *store.MockRepository) {
 				r.EXPECT().
-					Delete(gomock.Any(), gomock.Eq(serverID), gomock.Eq(ptypes.FirmwareInstallOutofband)).
+					Delete(gomock.Any(), gomock.Eq(serverID), gomock.Eq(ptypes.FirmwareInstall)).
 					Times(1).
 					Return(nil)
 			},
 			func(t *testing.T) *http.Request {
-				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstallOutofband)
+				url := fmt.Sprintf("/api/v1/servers/%s/condition/%s", serverID.String(), ptypes.FirmwareInstall)
 
 				request, err := http.NewRequestWithContext(context.TODO(), http.MethodDelete, url, http.NoBody)
 				if err != nil {

--- a/pkg/api/v1/types/types_test.go
+++ b/pkg/api/v1/types/types_test.go
@@ -63,7 +63,7 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 			},
 			&ptypes.Condition{
 				ID:              uuid.New(),
-				Kind:            ptypes.FirmwareInstallOutofband,
+				Kind:            ptypes.FirmwareInstall,
 				Parameters:      nil,
 				ResourceVersion: 1,
 				State:           ptypes.Pending,
@@ -82,7 +82,7 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 				Status:          []byte("{'foo': 'bar'}"),
 			},
 			&ptypes.Condition{
-				Kind:            ptypes.FirmwareInstallOutofband,
+				Kind:            ptypes.FirmwareInstall,
 				ID:              uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
 				Parameters:      nil,
 				ResourceVersion: 1,
@@ -91,7 +91,7 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 			},
 			&ptypes.Condition{
 				ID:              uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
-				Kind:            ptypes.FirmwareInstallOutofband,
+				Kind:            ptypes.FirmwareInstall,
 				Parameters:      nil,
 				ResourceVersion: 1,
 				State:           ptypes.Active,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,17 +35,6 @@ const (
 	// ConditionStructVersion identifies the condition struct revision
 	ConditionStructVersion string = "1"
 )
-
-func (k ConditionKind) EventType() string {
-	switch k {
-	case FirmwareInstallOutofband:
-		return fmt.Sprintf("firmware.%s", FirmwareInstallOutofband)
-	case InventoryOutofband:
-		return fmt.Sprintf("inventory.%s", InventoryOutofband)
-	default:
-		return string(k)
-	}
-}
 
 // ConditionState defines model for ConditionState.
 type ConditionState string

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,10 +22,10 @@ type ConditionKind string
 type EventUrnNamespace string
 
 const (
-	FirmwareInstallOutofband ConditionKind = "firmwareInstallOutofband"
-	InventoryOutofband       ConditionKind = "inventoryOutofband"
-	ServerResourceType       string        = "servers"
-	ConditionResourceType    string        = "condition"
+	FirmwareInstall       ConditionKind = "firmwareInstall"
+	InventoryOutofband    ConditionKind = "inventoryOutofband"
+	ServerResourceType    string        = "servers"
+	ConditionResourceType string        = "condition"
 
 	ServerserviceNamespace EventUrnNamespace = "hollow-serverservice"
 	ControllerUrnNamespace EventUrnNamespace = "hollow-controllers"


### PR DESCRIPTION
#### What does this PR do

- renames the condition kind `FirmwareInstallOutofband` to `FirmwareInstall`
- updates published subject to include condition kind as is.
- load a few more NATS config from env vars