### PR TITLE
Orchestrator fixes

### DIFF
--- a/pkg/api/v1/events/handlers.go
+++ b/pkg/api/v1/events/handlers.go
@@ -173,7 +173,7 @@ func (h *Handler) updateCondition(ctx context.Context, updEvt *v1types.Condition
 	}
 
 	// update
-	if err := h.repository.Update(ctx, updEvt.ConditionUpdate.ConditionID, revisedCondition); err != nil {
+	if err := h.repository.Update(ctx, updEvt.ServerID, revisedCondition); err != nil {
 		h.logger.WithError(err).WithFields(logrus.Fields{
 			"serverID":          updEvt.ConditionUpdate.ServerID,
 			"conditionID":       revisedCondition.ID,

--- a/pkg/api/v1/events/handlers.go
+++ b/pkg/api/v1/events/handlers.go
@@ -87,8 +87,14 @@ func (h *Handler) ControllerEvent(ctx context.Context, msg events.Message) {
 		},
 	).Debug("received controller event")
 
+	firmwareInstallUpdateEvt := fmt.Sprintf(
+		"servers.%s.%s",
+		ptypes.FirmwareInstall,
+		ptypes.ConditionUpdateEvent,
+	)
+
 	switch act {
-	case string(ptypes.ConditionUpdateEvent):
+	case string(firmwareInstallUpdateEvt):
 		var updateEvt v1types.ConditionUpdateEvent
 		if err := json.Unmarshal(msg.Data(), &updateEvt); err != nil {
 			h.logger.WithError(err).Warn("bogus condition update message")

--- a/pkg/api/v1/events/handlers.go
+++ b/pkg/api/v1/events/handlers.go
@@ -31,6 +31,12 @@ var (
 	controllerResponsePrefix = "com.hollow.sh.controllers.responses."
 
 	serverCreate = "server.create"
+
+	firmwareInstallUpdateSuffix = fmt.Sprintf(
+		"servers.%s.%s",
+		ptypes.FirmwareInstall,
+		ptypes.ConditionUpdateEvent,
+	)
 )
 
 //nolint:unused // we'll use this in the very near future
@@ -87,14 +93,8 @@ func (h *Handler) ControllerEvent(ctx context.Context, msg events.Message) {
 		},
 	).Debug("received controller event")
 
-	firmwareInstallUpdateEvt := fmt.Sprintf(
-		"servers.%s.%s",
-		ptypes.FirmwareInstall,
-		ptypes.ConditionUpdateEvent,
-	)
-
 	switch act {
-	case string(firmwareInstallUpdateEvt):
+	case string(firmwareInstallUpdateSuffix):
 		var updateEvt v1types.ConditionUpdateEvent
 		if err := json.Unmarshal(msg.Data(), &updateEvt); err != nil {
 			h.logger.WithError(err).Warn("bogus condition update message")

--- a/pkg/api/v1/events/handlers_test.go
+++ b/pkg/api/v1/events/handlers_test.go
@@ -21,6 +21,10 @@ import (
 	mock_events "go.hollow.sh/toolbox/events/mock"
 )
 
+var (
+	subject = "com.hollow.sh.controllers.responses.fc13." + firmwareInstallUpdateSuffix
+)
+
 func TestControllerEvent(t *testing.T) {
 	t.Parallel()
 	t.Run("bogus controller message", func(t *testing.T) {
@@ -50,7 +54,7 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return([]byte("garbage")),
 			msg.EXPECT().Ack().Times(1).Return(nil),
 		)
@@ -67,7 +71,7 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			// This is a valid JSON message that results in a zero-value (and thus invalid) update message
 			msg.EXPECT().Data().Times(1).Return([]byte(`{"garbage": "true"}`)),
 			msg.EXPECT().Ack().Times(1).Return(nil),
@@ -99,7 +103,7 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return(contentsBytes),
 			repo.EXPECT().Get(gomock.Any(), serverID, ptypes.InventoryOutofband).
 				Return(nil, errors.New("your princess is in another castle")),
@@ -132,7 +136,7 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return(contentsBytes),
 			repo.EXPECT().Get(gomock.Any(), serverID, ptypes.InventoryOutofband).
 				Return(nil, store.ErrConditionNotFound),
@@ -165,7 +169,7 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return(contentsBytes),
 			repo.EXPECT().Get(gomock.Any(), serverID, ptypes.InventoryOutofband).
 				Return(nil, nil),
@@ -203,7 +207,7 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return(contentsBytes),
 			repo.EXPECT().Get(gomock.Any(), serverID, ptypes.InventoryOutofband).
 				Return(existingCondition, nil),
@@ -241,7 +245,7 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return(contentsBytes),
 			repo.EXPECT().Get(gomock.Any(), serverID, ptypes.InventoryOutofband).
 				Return(existingCondition, nil),
@@ -281,11 +285,11 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return(contentsBytes),
 			repo.EXPECT().Get(gomock.Any(), serverID, ptypes.InventoryOutofband).
 				Times(1).Return(existingCondition, nil),
-			repo.EXPECT().Update(gomock.Any(), conditionID, gomock.Any()).Times(1).Return(errors.New("pound sand")),
+			repo.EXPECT().Update(gomock.Any(), serverID, gomock.Any()).Times(1).Return(errors.New("pound sand")),
 			msg.EXPECT().Nak().Times(1).Return(nil),
 		)
 		handler.ControllerEvent(context.TODO(), msg)
@@ -322,11 +326,11 @@ func TestControllerEvent(t *testing.T) {
 
 		handler := NewHandler(repo, stream, logrus.New())
 		gomock.InOrder(
-			msg.EXPECT().Subject().Times(1).Return("com.hollow.sh.controllers.responses.fc13.update"),
+			msg.EXPECT().Subject().Times(1).Return(subject),
 			msg.EXPECT().Data().Times(1).Return(contentsBytes),
 			repo.EXPECT().Get(gomock.Any(), serverID, ptypes.InventoryOutofband).
 				Times(1).Return(existingCondition, nil),
-			repo.EXPECT().Update(gomock.Any(), conditionID, gomock.Any()).Times(1).Return(nil),
+			repo.EXPECT().Update(gomock.Any(), serverID, gomock.Any()).Times(1).Return(nil),
 			msg.EXPECT().Ack().Times(1).Return(nil),
 		)
 		handler.ControllerEvent(context.TODO(), msg)

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -545,14 +545,14 @@ func TestServerConditionCreate(t *testing.T) {
 						gomock.Any(),
 					).
 					DoAndReturn(func(_ context.Context, _ uuid.UUID, c *ptypes.Condition) error {
-						expect := &ptypes.Fault{Panic: true, ExecuteWithDelay: 10 * time.Second, FailAt: "foobar"}
+						expect := &ptypes.Fault{Panic: true, DelayDuration: "10s", FailAt: "foobar"}
 						assert.Equal(t, c.Fault, expect)
 						return nil
 					}).
 					Times(1)
 			},
 			func(t *testing.T) *http.Request {
-				fault := ptypes.Fault{Panic: true, ExecuteWithDelay: 10 * time.Second, FailAt: "foobar"}
+				fault := ptypes.Fault{Panic: true, DelayDuration: "10s", FailAt: "foobar"}
 				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: []byte(`{"some param": "1"}`), Fault: &fault})
 				if err != nil {
 					t.Error(err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -164,7 +164,9 @@ type Fault struct {
 	Panic bool `json:"panic"`
 
 	// Introduce specified delay in execution of the condition on the controller.
-	ExecuteWithDelay time.Duration `json:"executionWithDelay,omitempty"`
+	//
+	// accepts the string format of time.Duration - 5s, 5m, 5h
+	DelayDuration string `json:"delayDuration,omitempty"`
 
 	// FailAt is a controller specific task/stage that the condition should fail in execution.
 	//


### PR DESCRIPTION
#### What does this PR do
- [v1/events/handlers: settle on a consistent controller response suffix](https://github.com/metal-toolbox/conditionorc/commit/0f401b9be28d10275ec7af274dceb28a22b3ba48)
- [v1/events: fixes incorrect server ID passed to store update](https://github.com/metal-toolbox/conditionorc/commit/98e1e8ecd21dd504e17650fb032332fb576a66b5)