### PR TITLE
CreateCondition to revert new condition on failure

### DIFF
--- a/pkg/api/v1/client/errors.go
+++ b/pkg/api/v1/client/errors.go
@@ -1,5 +1,7 @@
 package client
 
+import "fmt"
+
 // Error holds the cause of a client error and implements the Error interface.
 type Error struct {
 	Cause string
@@ -13,10 +15,10 @@ func (c Error) Error() string {
 // RequestError is returned when the client gets an error while performing a request.
 type RequestError struct {
 	Message    string `json:"message"`
-	StatusCode int    `json:"stateusCode"`
+	StatusCode int    `json:"statusCode"`
 }
 
 // Error returns the RequestError in string format
 func (e RequestError) Error() string {
-	return "conditionorc client request error: " + e.Message
+	return fmt.Sprintf("conditionorc client request error, statusCode: %d, message: %s", e.StatusCode, e.Message)
 }


### PR DESCRIPTION
#### What does this PR do

- When a newly created condition fails to get published on the event stream, the new condition is then purged,
and an error is returned to the client.

- Conditionorc client to format errors with returned status code.