### PR TITLE
Vc/dynamic kvs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,6 @@ linters:
     - misspell
     - noctx
     - stylecheck
-    - whitespace
     - gosec
   enable-all: false
   disable-all: true

--- a/cmd/orchestrator.go
+++ b/cmd/orchestrator.go
@@ -70,6 +70,7 @@ var cmdOrchestrator = &cobra.Command{
 			orchestrator.WithStreamBroker(streamBroker),
 			orchestrator.WithNotifier(notifier),
 			orchestrator.WithFacility(facility),
+			orchestrator.WithConditionDefs(app.Config.ConditionDefinitions),
 		}
 
 		app.Logger.Info("configuring status KV support")

--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,11 @@ require (
 	github.com/volatiletech/null/v8 v8.1.2
 	go.hollow.sh/serverservice v0.16.0
 	go.hollow.sh/toolbox v0.6.1
+	go.opencensus.io v0.24.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
+	go.uber.org/goleak v1.2.1
 	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 	golang.org/x/oauth2 v0.11.0
 	gopkg.in/square/go-jose.v2 v2.6.0
@@ -109,7 +111,6 @@ require (
 	github.com/volatiletech/sqlboiler v3.7.1+incompatible // indirect
 	github.com/volatiletech/sqlboiler/v4 v4.14.2 // indirect
 	github.com/volatiletech/strmangle v0.0.5 // indirect
-	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -723,6 +723,7 @@ go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/metal-toolbox/conditionorc/internal/store"
 	"github.com/metal-toolbox/conditionorc/internal/version"
 	v1EventHandlers "github.com/metal-toolbox/conditionorc/pkg/api/v1/events"
+	ptypes "github.com/metal-toolbox/conditionorc/pkg/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.hollow.sh/toolbox/events"
@@ -37,6 +38,7 @@ type Orchestrator struct {
 	replicaCount  int
 	notifier      notify.Sender
 	facility      string
+	conditionDefs ptypes.ConditionDefinitions
 }
 
 // Option type sets a parameter on the Orchestrator type.
@@ -97,6 +99,14 @@ func WithNotifier(s notify.Sender) Option {
 func WithFacility(f string) Option {
 	return func(o *Orchestrator) {
 		o.facility = f
+	}
+}
+
+// WithConditionDefs sets the configured condition definitions where the orchestrator
+// can access them at runtime.
+func WithConditionDefs(defs ptypes.ConditionDefinitions) Option {
+	return func(o *Orchestrator) {
+		o.conditionDefs = defs
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -136,7 +136,7 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		"AppVersion": v.AppVersion,
 	}).Info("running orchestrator")
 	o.startWorkerLivenessCheckin(ctx)
-	o.startUpdateListener(ctx)
+	o.startUpdateMonitor(ctx)
 	o.startEventListener(ctx)
 
 	<-ctx.Done()

--- a/internal/status/kv.go
+++ b/internal/status/kv.go
@@ -64,14 +64,14 @@ func WatchConditionStatus(ctx context.Context, kind ptypes.ConditionKind, facili
 		return nil, errNotReady
 	}
 
-	kv, ok := kvCollection[string(kind)]
+	bucket, ok := kvCollection[string(kind)]
 	if !ok {
 		return nil, errors.Wrap(errNoKV, string(kind))
 	}
 
 	// format the facility as a NATS subject to use as a filter for relevant KVs
 	keyStr := fmt.Sprintf("%s.*", facility)
-	return kv.Watch(keyStr, nats.Context(ctx))
+	return bucket.Watch(keyStr, nats.Context(ctx))
 }
 
 // GetConditionKV returns the raw NATS KeyValue interface for the bucket associated
@@ -81,10 +81,10 @@ func GetConditionKV(kind ptypes.ConditionKind) (nats.KeyValue, error) {
 		return nil, errNotReady
 	}
 
-	kv, ok := kvCollection[string(kind)]
+	bucket, ok := kvCollection[string(kind)]
 	if !ok {
 		return nil, errors.Wrap(errNoKV, string(kind))
 	}
 
-	return kv, nil
+	return bucket, nil
 }

--- a/internal/status/kv.go
+++ b/internal/status/kv.go
@@ -3,9 +3,11 @@ package status
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	ptypes "github.com/metal-toolbox/conditionorc/pkg/types"
+	"github.com/pkg/errors"
 
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
@@ -14,14 +16,19 @@ import (
 )
 
 var (
-	statusTTL         = 10 * 24 * time.Hour // expire status information in 10 days
-	firmwareInstallKV nats.KeyValue
+	statusOnce   sync.Once
+	statusTTL    = 10 * 24 * time.Hour // expire status information in 10 days
+	kvCollection = map[string]nats.KeyValue{}
+	errNotReady  = errors.New("condition kvs not initialized")
+	errNoKV      = errors.New("no kv for condition")
+	kvReady      bool
 )
 
 // ConnectToKVStores initializes all status KVs in preparation for monitoring status updates
 // Any errors here are fatal, as we are failing to initialize something we are explicitly
 // configured for.
-func ConnectToKVStores(s events.Stream, log *logrus.Logger, opts ...kv.Option) {
+func ConnectToKVStores(s events.Stream, log *logrus.Logger,
+	defs ptypes.ConditionDefinitions, opts ...kv.Option) {
 	js, ok := s.(*events.NatsJetstream)
 	if !ok {
 		log.Fatal("status via KV updates is only supported on NATS")
@@ -35,22 +42,49 @@ func ConnectToKVStores(s events.Stream, log *logrus.Logger, opts ...kv.Option) {
 		statusOpts = append(statusOpts, opts...)
 	}
 
-	var err error
-	firmwareInstallKV, err = kv.CreateOrBindKVBucket(js, string(ptypes.FirmwareInstall), statusOpts...)
-	if err != nil {
-		log.WithError(err).Fatal("unable to initialize NATS KV for firmware install")
-	}
-	//nolint:gocritic // shut up I know it's commented out.
-	/* inventoryKV, err := kv.CreateOrBindKV(js, string(ptypes.InventoryOutofband), opts...)
-		if err != nil {
-		log.WithErr(err).Fatal("unable to initialize NATS KV for inventory")
-	}*/
+	statusOnce.Do(func() {
+		for _, def := range defs {
+			kind := string(def.Kind)
+			hdl, err := kv.CreateOrBindKVBucket(js, kind, statusOpts...)
+			if err != nil {
+				log.WithError(err).
+					WithField("kv.type", kind).
+					Fatal("unable to initialize NATS KV for status")
+			}
+			kvCollection[kind] = hdl
+		}
+		kvReady = true
+	})
 }
 
-// WatchFirmwareInstallStatus specializes some generic NATS functionality, mainly to keep
+// WatchConditionStatus specializes some generic NATS functionality, mainly to keep
 // the callers cleaner of the NATS-specific details.
-func WatchFirmwareInstallStatus(ctx context.Context, facility string) (nats.KeyWatcher, error) {
+func WatchConditionStatus(ctx context.Context, kind ptypes.ConditionKind, facility string) (nats.KeyWatcher, error) {
+	if !kvReady {
+		return nil, errNotReady
+	}
+
+	kv, ok := kvCollection[string(kind)]
+	if !ok {
+		return nil, errors.Wrap(errNoKV, string(kind))
+	}
+
 	// format the facility as a NATS subject to use as a filter for relevant KVs
 	keyStr := fmt.Sprintf("%s.*", facility)
-	return firmwareInstallKV.Watch(keyStr, nats.Context(ctx))
+	return kv.Watch(keyStr, nats.Context(ctx))
+}
+
+// GetConditionKV returns the raw NATS KeyValue interface for the bucket associated
+// with the given condition type.
+func GetConditionKV(kind ptypes.ConditionKind) (nats.KeyValue, error) {
+	if !kvReady {
+		return nil, errNotReady
+	}
+
+	kv, ok := kvCollection[string(kind)]
+	if !ok {
+		return nil, errors.Wrap(errNoKV, string(kind))
+	}
+
+	return kv, nil
 }

--- a/internal/status/kv_test.go
+++ b/internal/status/kv_test.go
@@ -1,0 +1,108 @@
+package status
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	ptypes "github.com/metal-toolbox/conditionorc/pkg/types"
+
+	"github.com/nats-io/nats-server/v2/server"
+	srvtest "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.hollow.sh/toolbox/events"
+)
+
+func init() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+}
+
+func startJetStreamServer(t *testing.T) *server.Server {
+	t.Helper()
+	opts := srvtest.DefaultTestOptions
+	opts.Port = -1
+	opts.JetStream = true
+	return srvtest.RunServer(&opts)
+}
+
+func jetStreamContext(t *testing.T, s *server.Server) (*nats.Conn, nats.JetStreamContext) {
+	t.Helper()
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("connect => %v", err)
+	}
+	js, err := nc.JetStream(nats.MaxWait(10 * time.Second))
+	if err != nil {
+		t.Fatalf("JetStream => %v", err)
+	}
+	return nc, js
+}
+
+func shutdownJetStream(t *testing.T, s *server.Server) {
+	t.Helper()
+	var sd string
+	if config := s.JetStreamConfig(); config != nil {
+		sd = config.StoreDir
+	}
+	s.Shutdown()
+	if sd != "" {
+		if err := os.RemoveAll(sd); err != nil {
+			t.Fatalf("Unable to remove storage %q: %v", sd, err)
+		}
+	}
+	s.WaitForShutdown()
+}
+
+type shutdownFunc func()
+
+func startTestJetStream(t *testing.T) (*events.NatsJetstream, shutdownFunc) {
+	t.Helper()
+	srv := startJetStreamServer(t)
+	conn, _ := jetStreamContext(t, srv)
+	evJS := events.NewJetstreamFromConn(conn)
+	return evJS, func() {
+		evJS.Close()
+		shutdownJetStream(t, srv)
+	}
+}
+
+func TestStatusKV(t *testing.T) {
+	t.Parallel()
+	js, testDone := startTestJetStream(t)
+	defer testDone()
+
+	defs := ptypes.ConditionDefinitions{
+		&ptypes.ConditionDefinition{
+			Kind:      ptypes.ConditionKind("test-event"),
+			Exclusive: true,
+		},
+	}
+
+	// pre-ready returns an error
+	require.False(t, kvReady)
+	_, err := WatchConditionStatus(context.TODO(), ptypes.ConditionKind("bogus"), "my-facility")
+	require.ErrorIs(t, err, errNotReady, "wrong error")
+
+	_, err = GetConditionKV(ptypes.ConditionKind("bogus"))
+	require.ErrorIs(t, err, errNotReady, "wrong error")
+
+	ConnectToKVStores(js, &logrus.Logger{}, defs)
+	require.True(t, kvReady)
+
+	// bogus condition name returns an error
+	_, err = WatchConditionStatus(context.TODO(), ptypes.ConditionKind("bogus"), "my-facility")
+	require.ErrorIs(t, err, errNoKV, "wrong error")
+
+	_, err = GetConditionKV(ptypes.ConditionKind("bogus"))
+	require.ErrorIs(t, err, errNoKV, "wrong error")
+
+	// use the configured kind and get a real object back
+	_, err = WatchConditionStatus(context.TODO(), ptypes.ConditionKind("test-event"), "my-facility")
+	require.NoError(t, err)
+
+	_, err = GetConditionKV(ptypes.ConditionKind("test-event"))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
#### What does this PR do

Instead of hard-coding a watcher for `FirmwareInstall` use the configured ConditionDefinitions to create the required watchers and manage them in a dynamic way. This paves the way for adding status monitoring for Alloy as well.