### PR TITLE
transform a key-value entry to a ConditionUpdate in a data-agnostic way

### DIFF
--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -105,14 +105,6 @@ func (o *Orchestrator) startConditionWatchers(ctx context.Context,
 
 		kind := def.Kind
 
-		switch kind {
-		case ptypes.FirmwareInstall:
-		case ptypes.InventoryOutofband:
-		default:
-			o.logger.WithField("condition.kind", string(kind)).Warn("unsupported condition")
-			continue
-		}
-
 		wg.Add(1)
 
 		watcher, err := status.WatchConditionStatus(ctx, kind, o.facility)

--- a/internal/orchestrator/updates_test.go
+++ b/internal/orchestrator/updates_test.go
@@ -134,7 +134,7 @@ func TestInstallEventFromKV(t *testing.T) {
 	entry, err := writeHandle.Get(k1)
 	require.NoError(t, err)
 
-	upd1, err := installEventFromKV(context.Background(), entry)
+	upd1, err := eventUpdateFromKV(context.Background(), entry, ptypes.FirmwareInstall)
 	require.NoError(t, err)
 	require.Equal(t, condID, upd1.ConditionUpdate.ConditionID)
 	require.Equal(t, ptypes.Pending, upd1.ConditionUpdate.State)
@@ -142,13 +142,13 @@ func TestInstallEventFromKV(t *testing.T) {
 	// bogus state should error
 	entry, err = writeHandle.Get(k2)
 	require.NoError(t, err)
-	_, err = installEventFromKV(context.Background(), entry)
+	_, err = eventUpdateFromKV(context.Background(), entry, ptypes.FirmwareInstall)
 	require.ErrorIs(t, errInvalidState, err)
 
 	// stale event should error as well
 	entry, err = writeHandle.Get(k3)
 	require.NoError(t, err)
-	_, err = installEventFromKV(context.Background(), entry)
+	_, err = eventUpdateFromKV(context.Background(), entry, ptypes.FirmwareInstall)
 	require.ErrorIs(t, errStaleEvent, err)
 }
 


### PR DESCRIPTION
#### What does this PR do
This modifies the function that produces ConditionUpdateEvents from controller status. A key insight was that the `Kind` value was constant in the original function, but now can be parameterized.
