### PR TITLE
make worker-id easier to track

### DIFF
--- a/internal/orchestrator/liveness.go
+++ b/internal/orchestrator/liveness.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -48,7 +49,8 @@ func (o *Orchestrator) startWorkerLivenessCheckin(ctx context.Context) {
 }
 
 func (o *Orchestrator) checkinRoutine(ctx context.Context) {
-	me := registry.GetID("condition-orchestrator")
+	workerName := fmt.Sprintf("orchestrator-%s", o.facility)
+	me := registry.GetID(workerName)
 	o.logger.WithField("id", me.String()).Info("worker id assigned")
 	if err := registry.RegisterController(me); err != nil {
 		metrics.DependencyError("liveness", "register")


### PR DESCRIPTION
#### What does this PR do
Change the controller id of `condition-orchestrator` so it's easier to follow now that orchestrator is in all edge clusters
