### PR TITLE
Vc/multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.18.0
+RUN apk -U add curl
 
 ENTRYPOINT ["/usr/sbin/conditionorc"]
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,38 @@
+FROM golang:1.21.1-alpine3.18 AS deps
+
+WORKDIR /go/src/github.com/metal-toolbox/conditionorc
+COPY go.mod go.sum ./
+RUN go mod download
+WORKDIR /go
+COPY pkg ./pkg
+
+FROM deps AS builder 
+WORKDIR /go/src/github.com/metal-toolbox/conditionorc
+ARG LDFLAG_LOCATION=github.com/metal-toolbox/conditionorc/internal/version
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+ARG GIT_SUMMARY
+ARG VERSION
+ARG BUILD_DATE
+
+COPY main.go ./
+COPY cmd ./cmd/
+COPY internal ./internal 
+COPY pkg ./pkg
+
+RUN GOOS=linux GOARCH=amd64 go build -o /bin/conditionorc \
+-ldflags \
+"-X ${LDFLAG_LOCATION}.GitCommit=${GIT_COMMIT} \
+-X ${LDFLAG_LOCATION}.GitBranch=${GIT_BRANCH} \
+-X ${LDFLAG_LOCATION}.GitSummary=${GIT_SUMMARY} \
+-X ${LDFLAG_LOCATION}.AppVersion=${VERSION} \
+-X ${LDFLAG_LOCATION}.BuildDate=${BUILD_DATE}"
+
+FROM alpine:3.18.0
+RUN apk -U add curl
+
+WORKDIR /usr/sbin/
+
+COPY --from=builder --chmod=755 /bin/conditionorc .
+
+ENTRYPOINT ["/usr/sbin/conditionorc"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION     := $(shell git describe --tags 2> /dev/null)
 BUILD_DATE  := $(shell date +%s)
 GIT_COMMIT_FULL  := $(shell git rev-parse HEAD)
 GO_VERSION := $(shell expr `go version |cut -d ' ' -f3 |cut -d. -f2` \>= 16)
-DOCKER_IMAGE  := "ghcr.io/metal-toolbox/conditionorc"
+DOCKER_IMAGE  ?= "ghcr.io/metal-toolbox/conditionorc"
 REPO := "https://github.com/metal-toolbox/conditionorc.git"
 
 .DEFAULT_GOAL := help
@@ -83,6 +83,14 @@ ifndef SWAG_INSTALLED
 	go install github.com/swaggo/swag/cmd/swag@latest
 endif
 	swag init --parseDependency --parseDepth 1
+
+# experimental
+multistage-image:
+	docker build -f Dockerfile.builder -t ${DOCKER_IMAGE}:latest . \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GIT_BRANCH=$(GIT_BRANCH) \
+		--build-arg GIT_SUMMARY=$(GIT_SUMMARY) --build-arg VERSION=$(VERSION) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) --label org.label-schema.schema-version=1.0 \
+		--label org.label-schema.vcs-ref=$(GIT_COMMIT_FULL) --label=org.label-schema.vcs-url=$(REPO)
 
 
 # https://gist.github.com/prwhite/8168133


### PR DESCRIPTION
#### What does this PR do
Adds a (currently experimental) multistage build so that we can more carefully control production builds (and still get the same caching benefits as we currently do). It also provides a simple way to override the docker image name. Finally, we add curl to the orchestrator image to assist in debugging some Slack notification issues we're seeing.
