### PR TITLE
Simpler dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+.git
+!**.go
+!go.*
+!conditionorc

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,13 +1,9 @@
-FROM golang:1.21.1-alpine3.18 AS deps
+FROM golang:1.21.1-alpine3.18 AS build
 
 WORKDIR /go/src/github.com/metal-toolbox/conditionorc
 COPY go.mod go.sum ./
 RUN go mod download
-WORKDIR /go
-COPY pkg ./pkg
 
-FROM deps AS builder 
-WORKDIR /go/src/github.com/metal-toolbox/conditionorc
 ARG LDFLAG_LOCATION=github.com/metal-toolbox/conditionorc/internal/version
 ARG GIT_COMMIT
 ARG GIT_BRANCH
@@ -15,12 +11,9 @@ ARG GIT_SUMMARY
 ARG VERSION
 ARG BUILD_DATE
 
-COPY main.go ./
-COPY cmd ./cmd/
-COPY internal ./internal 
-COPY pkg ./pkg
+COPY . ./
 
-RUN GOOS=linux GOARCH=amd64 go build -o /bin/conditionorc \
+RUN GOOS=linux GOARCH=amd64 go build -o /usr/sbin/conditionorc \
 -ldflags \
 "-X ${LDFLAG_LOCATION}.GitCommit=${GIT_COMMIT} \
 -X ${LDFLAG_LOCATION}.GitBranch=${GIT_BRANCH} \
@@ -31,8 +24,6 @@ RUN GOOS=linux GOARCH=amd64 go build -o /bin/conditionorc \
 FROM alpine:3.18.0
 RUN apk -U add curl
 
-WORKDIR /usr/sbin/
-
-COPY --from=builder --chmod=755 /bin/conditionorc .
+COPY --from=build /usr/sbin/conditionorc /usr/sbin/
 
 ENTRYPOINT ["/usr/sbin/conditionorc"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/metal-toolbox/conditionorc/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -29,8 +30,9 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "conditionorc",
-	Short: "server condition orchestrator",
+	Use:     "conditionorc",
+	Short:   "server condition orchestrator",
+	Version: version.Current().String(),
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,9 +18,7 @@ import (
 	"go.hollow.sh/toolbox/events"
 )
 
-var (
-	shutdownTimeout = 10 * time.Second
-)
+var shutdownTimeout = 10 * time.Second
 
 // install server command
 var cmdServer = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/volatiletech/null/v8 v8.1.2
 	go.hollow.sh/serverservice v0.16.0
 	go.hollow.sh/toolbox v0.6.1
-	go.opencensus.io v0.24.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
@@ -123,6 +122,7 @@ require (
 	github.com/volatiletech/sqlboiler v3.7.1+incompatible // indirect
 	github.com/volatiletech/sqlboiler/v4 v4.14.2 // indirect
 	github.com/volatiletech/strmangle v0.0.5 // indirect
+	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.16.0 // indirect

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -14,9 +14,7 @@ import (
 	"go.hollow.sh/toolbox/ginjwt"
 )
 
-var (
-	ErrConfig = errors.New("configuration error")
-)
+var ErrConfig = errors.New("configuration error")
 
 // Configuration holds application configuration read from a YAML or set by env variables.
 //

--- a/internal/orchestrator/events.go
+++ b/internal/orchestrator/events.go
@@ -5,9 +5,7 @@ import (
 	"sync"
 )
 
-var (
-	evtOnce sync.Once
-)
+var evtOnce sync.Once
 
 func (o *Orchestrator) startEventListener(ctx context.Context) {
 	evtOnce.Do(func() {

--- a/internal/orchestrator/notify/slack_test.go
+++ b/internal/orchestrator/notify/slack_test.go
@@ -28,7 +28,7 @@ func startServer() {
 }
 
 func TestSlackSend(t *testing.T) {
-	//var timestampExpected bool
+	// var timestampExpected bool
 	http.DefaultServeMux = new(http.ServeMux)
 	http.HandleFunc("/chat.postMessage", func(rw http.ResponseWriter, r *http.Request) {
 		r.ParseForm()

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -103,8 +103,8 @@ func (o *Orchestrator) kvStatusPublisher(ctx context.Context) {
 // and start a KV watcher for each one. We increment the waitgroup counter for each condition we
 // can handle.
 func (o *Orchestrator) startConditionWatchers(ctx context.Context,
-	evtChan chan<- *v1types.ConditionUpdateEvent, wg *sync.WaitGroup) {
-
+	evtChan chan<- *v1types.ConditionUpdateEvent, wg *sync.WaitGroup,
+) {
 	for _, def := range o.conditionDefs {
 		var watcher nats.KeyWatcher
 
@@ -191,7 +191,8 @@ type controllerStatus struct {
 // ConditionOrchestrator-native type that ConditionOrc can more-easily use for its
 // own purposes.
 func eventUpdateFromKV(ctx context.Context, kve nats.KeyValueEntry,
-	kind ptypes.ConditionKind) (*v1types.ConditionUpdateEvent, error) {
+	kind ptypes.ConditionKind,
+) (*v1types.ConditionUpdateEvent, error) {
 	parsedKey, err := parseStatusKVKey(kve.Key())
 	if err != nil {
 		return nil, err

--- a/internal/status/kv.go
+++ b/internal/status/kv.go
@@ -28,7 +28,8 @@ var (
 // Any errors here are fatal, as we are failing to initialize something we are explicitly
 // configured for.
 func ConnectToKVStores(s events.Stream, log *logrus.Logger,
-	defs ptypes.ConditionDefinitions, opts ...kv.Option) {
+	defs ptypes.ConditionDefinitions, opts ...kv.Option,
+) {
 	js, ok := s.(*events.NatsJetstream)
 	if !ok {
 		log.Fatal("status via KV updates is only supported on NATS")

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -49,9 +49,7 @@ type Repository interface {
 	Delete(ctx context.Context, serverID uuid.UUID, conditionKind ptypes.ConditionKind) error
 }
 
-var (
-	ErrRepository = errors.New("storage repository error")
-)
+var ErrRepository = errors.New("storage repository error")
 
 func NewStore(ctx context.Context, config *app.Configuration, conditionDefs ptypes.ConditionDefinitions, logger *logrus.Logger) (Repository, error) {
 	switch config.StoreKind {

--- a/internal/store/serverservice.go
+++ b/internal/store/serverservice.go
@@ -142,7 +142,8 @@ func (s *Serverservice) Ping(_ context.Context) error {
 // @id: required
 // @conditionKind: required
 func (s *Serverservice) Get(ctx context.Context, serverID uuid.UUID,
-	conditionKind ptypes.ConditionKind) (*ptypes.Condition, error) {
+	conditionKind ptypes.ConditionKind,
+) (*ptypes.Condition, error) {
 	otelCtx, span := otel.Tracer(pkgName).Start(ctx, "Serverservice.Get")
 	defer span.End()
 	// list attributes on a server
@@ -206,7 +207,8 @@ func (s *Serverservice) GetServer(ctx context.Context, serverID uuid.UUID) (*mod
 // @id: required
 // @conditionState: optional
 func (s *Serverservice) List(ctx context.Context, serverID uuid.UUID,
-	conditionState ptypes.ConditionState) ([]*ptypes.Condition, error) {
+	conditionState ptypes.ConditionState,
+) ([]*ptypes.Condition, error) {
 	otelCtx, span := otel.Tracer(pkgName).Start(ctx, "Serverservice.List")
 	defer span.End()
 	found := []*sservice.Attributes{}
@@ -329,7 +331,8 @@ func (s *Serverservice) Delete(ctx context.Context, serverID uuid.UUID, conditio
 
 // ListServersWithCondition lists servers with the given condition kind.
 func (s *Serverservice) ListServersWithCondition(ctx context.Context,
-	conditionKind ptypes.ConditionKind, conditionState ptypes.ConditionState) ([]*ptypes.ServerConditions, error) {
+	conditionKind ptypes.ConditionKind, conditionState ptypes.ConditionState,
+) ([]*ptypes.ServerConditions, error) {
 	otelCtx, span := otel.Tracer(pkgName).Start(ctx, "Serverservice.ListServersWithCondition")
 	defer span.End()
 	params := &sservice.ServerListParams{

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,7 +3,7 @@ package version
 import (
 	"fmt"
 	"runtime"
-	rdebug "runtime/debug"
+	"runtime/debug"
 	"strings"
 )
 
@@ -44,7 +44,7 @@ func (v *Version) String() string {
 }
 
 func serverserviceVersion() string {
-	buildInfo, ok := rdebug.ReadBuildInfo()
+	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
 		return ""
 	}

--- a/pkg/api/v1/client/client_test.go
+++ b/pkg/api/v1/client/client_test.go
@@ -210,7 +210,6 @@ func TestIntegration_AuthToken(t *testing.T) {
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
 				})
-
 				if err != nil {
 					t.Error(err)
 				}
@@ -238,7 +237,6 @@ func TestIntegration_AuthToken(t *testing.T) {
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
 				})
-
 				if err != nil {
 					t.Error(err)
 				}
@@ -312,7 +310,6 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
 				})
-
 				if err != nil {
 					t.Error(err)
 				}
@@ -340,7 +337,6 @@ func TestIntegration_ConditionsGet(t *testing.T) {
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
 				})
-
 				if err != nil {
 					t.Error(err)
 				}
@@ -451,7 +447,6 @@ func TestIntegration_ConditionsList(t *testing.T) {
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
 				})
-
 				if err != nil {
 					t.Error(err)
 				}
@@ -487,7 +482,6 @@ func TestIntegration_ConditionsList(t *testing.T) {
 					ForceInstall:         true,
 					FirmwareSetID:        "fake",
 				})
-
 				if err != nil {
 					t.Error(err)
 				}

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -856,7 +856,6 @@ func TestServerConditionCreate(t *testing.T) {
 					Delete(gomock.Any(), gomock.Eq(serverID), gomock.Eq(ptypes.FirmwareInstall)).
 					Times(1).
 					Return(nil)
-
 			},
 			func(r *mockevents.MockStream) {
 				r.EXPECT().


### PR DESCRIPTION
#### What does this PR do

This PR simplifies the Dockerfile.builder to avoid some things were unnecessary. There's no need for both the deps and builder stages as they can just be combined into one, caching still works right. Also the previous Dockerfiles was copying ./pkg to /go/pkg (go toolchain's pkg...) unnecessarily and probably a footgun waiting to fire...?