### PR TITLE
take multi-token auth config instead of individual variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ multistage-image:
 		--build-arg BUILD_DATE=$(BUILD_DATE) --label org.label-schema.schema-version=1.0 \
 		--label org.label-schema.vcs-ref=$(GIT_COMMIT_FULL) --label=org.label-schema.vcs-url=$(REPO)
 
+push-ms-devel: multistage-image
+	docker tag ${DOCKER_IMAGE}:latest localhost:5001/conditionorc:latest
+	docker push localhost:5001/conditionorc:latest
+	kind load docker-image localhost:5001/conditionorc:latest
 
 # https://gist.github.com/prwhite/8168133
 # COLORS

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -91,5 +91,6 @@ var cmdServer = &cobra.Command{
 // install command flags
 func init() {
 	rootCmd.AddCommand(cmdServer)
-	ginjwt.RegisterViperOIDCFlags(viper.GetViper(), cmdServer)
+	cmdServer.Flags().Bool("oidc", true, "use oidc auth")
+	ginjwt.BindFlagFromViperInst(viper.GetViper(), "oidc.enabled", cmdServer.Flags().Lookup("oidc"))
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,7 +15,9 @@ import (
 	"github.com/metal-toolbox/conditionorc/internal/server"
 	"github.com/metal-toolbox/conditionorc/internal/store"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"go.hollow.sh/toolbox/events"
+	"go.hollow.sh/toolbox/ginjwt"
 )
 
 var shutdownTimeout = 10 * time.Second
@@ -56,7 +58,13 @@ var cmdServer = &cobra.Command{
 			server.WithStore(repository),
 			server.WithStreamBroker(streamBroker),
 			server.WithConditionDefinitions(app.Config.ConditionDefinitions),
-			server.WithAuthMiddlewareConfig(app.Config.APIServerJWTAuth),
+		}
+
+		if viper.GetViper().GetBool("oidc.enabled") {
+			app.Logger.Info("enabling OIDC")
+			options = append(options, server.WithAuthMiddlewareConfig(app.Config.APIServerJWTAuth))
+		} else {
+			app.Logger.Info("OIDC disabled")
 		}
 
 		srv := server.New(options...)
@@ -83,4 +91,5 @@ var cmdServer = &cobra.Command{
 // install command flags
 func init() {
 	rootCmd.AddCommand(cmdServer)
+	ginjwt.RegisterViperOIDCFlags(viper.GetViper(), cmdServer)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ var (
 // Server type holds attributes of the condition orc server
 type Server struct {
 	// Logger is the app logger
-	authMWConfig         *ginjwt.AuthConfig
+	authMWConfigs        []ginjwt.AuthConfig
 	logger               *logrus.Logger
 	streamBroker         events.Stream
 	listenAddress        string
@@ -78,9 +78,9 @@ func WithConditionDefinitions(defs rctypes.Definitions) Option {
 }
 
 // WithAuthMiddlewareConfig sets the auth middleware configuration.
-func WithAuthMiddlewareConfig(authMWConfig *ginjwt.AuthConfig) Option {
+func WithAuthMiddlewareConfig(authMWConfigs []ginjwt.AuthConfig) Option {
 	return func(s *Server) {
-		s.authMWConfig = authMWConfig
+		s.authMWConfigs = authMWConfigs
 	}
 }
 
@@ -104,8 +104,8 @@ func New(opts ...Option) *http.Server {
 	}
 
 	// add auth middleware
-	if s.authMWConfig != nil && s.authMWConfig.Enabled {
-		authMW, err := ginjwt.NewAuthMiddleware(*s.authMWConfig)
+	if s.authMWConfigs != nil {
+		authMW, err := ginjwt.NewMultiTokenMiddlewareFromConfigs(s.authMWConfigs...)
 		if err != nil {
 			s.logger.Fatal("failed to initialize auth middleware: ", "error", err)
 		}


### PR DESCRIPTION
#### What does this PR do
This PR changes condition-api from being configured to accept OIDC authentication via environment variables to being configured via the Kubernetes config-map (mounted as a configuration file).