### PR TITLE
Vc/nats condition tracking

### DIFF
--- a/cmd/orchestrator.go
+++ b/cmd/orchestrator.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/equinix-labs/otel-init-go/otelinit"
@@ -17,8 +18,7 @@ import (
 )
 
 var (
-	replicaCount int
-	facility     string
+	facility string
 )
 
 // install orchestrator command
@@ -52,7 +52,7 @@ var cmdOrchestrator = &cobra.Command{
 			app.Logger.Fatal(err)
 		}
 
-		if err := streamBroker.Open(); err != nil {
+		if err = streamBroker.Open(); err != nil {
 			app.Logger.Fatal(err)
 		}
 
@@ -73,8 +73,12 @@ var cmdOrchestrator = &cobra.Command{
 			orchestrator.WithConditionDefs(app.Config.ConditionDefinitions),
 		}
 
-		app.Logger.Info("configuring status KV support")
-		options = append(options, orchestrator.WithReplicas(replicaCount))
+		if app.Config.NatsOptions.KVReplicationFactor > 0 {
+			app.Logger.WithField("replication",
+				fmt.Sprintf("%d", app.Config.NatsOptions.KVReplicationFactor)).
+				Info("configuring status KV support")
+			options = append(options, orchestrator.WithReplicas(app.Config.NatsOptions.KVReplicationFactor))
+		}
 
 		orc := orchestrator.New(options...)
 		orc.Run(ctx)
@@ -84,9 +88,6 @@ var cmdOrchestrator = &cobra.Command{
 // install command flags
 func init() {
 	pflags := cmdOrchestrator.PersistentFlags()
-	pflags.IntVarP(&replicaCount, "replica-count", "r", 3,
-		"the number of replicas to configure for the NATS status KV store")
-
 	pflags.StringVarP(&facility, "facility", "f", "", "a site-specific token to focus this orchestrator's activities")
 
 	if err := cmdOrchestrator.MarkPersistentFlagRequired("facility"); err != nil {

--- a/cmd/orchestrator.go
+++ b/cmd/orchestrator.go
@@ -47,17 +47,17 @@ var cmdOrchestrator = &cobra.Command{
 			cancelFunc()
 		}()
 
-		repository, err := store.NewStore(ctx, app.Config, app.Config.ConditionDefinitions, app.Logger)
-		if err != nil {
-			app.Logger.Fatal(err)
-		}
-
 		streamBroker, err := events.NewStream(app.Config.NatsOptions)
 		if err != nil {
 			app.Logger.Fatal(err)
 		}
 
 		if err := streamBroker.Open(); err != nil {
+			app.Logger.Fatal(err)
+		}
+
+		repository, err := store.NewStore(ctx, app.Config, app.Config.ConditionDefinitions, app.Logger, streamBroker)
+		if err != nil {
 			app.Logger.Fatal(err)
 		}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -32,17 +32,17 @@ var cmdServer = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		repository, err := store.NewStore(cmd.Context(), app.Config, app.Config.ConditionDefinitions, app.Logger)
-		if err != nil {
-			app.Logger.Fatal(err)
-		}
-
 		streamBroker, err := events.NewStream(app.Config.NatsOptions)
 		if err != nil {
 			app.Logger.Fatal(err)
 		}
 
 		if err := streamBroker.Open(); err != nil {
+			app.Logger.Fatal(err)
+		}
+
+		repository, err := store.NewStore(app.Config, app.Config.ConditionDefinitions, app.Logger, streamBroker)
+		if err != nil {
 			app.Logger.Fatal(err)
 		}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -37,11 +37,14 @@ var cmdServer = &cobra.Command{
 			app.Logger.Fatal(err)
 		}
 
-		if err := streamBroker.Open(); err != nil {
+		if err = streamBroker.Open(); err != nil {
 			app.Logger.Fatal(err)
 		}
 
-		repository, err := store.NewStore(app.Config, app.Config.ConditionDefinitions, app.Logger, streamBroker)
+		// setup cancel context with cancel func
+		ctx, serverCancel := context.WithCancel(cmd.Context())
+
+		repository, err := store.NewStore(ctx, app.Config, app.Config.ConditionDefinitions, app.Logger, streamBroker)
 		if err != nil {
 			app.Logger.Fatal(err)
 		}
@@ -77,6 +80,7 @@ var cmdServer = &cobra.Command{
 		// sit around for term signal
 		<-termCh
 		app.Logger.Info("got TERM signal, shutting down server...")
+		serverCancel()
 
 		// call server shutdown with timeout
 		ctx, cancel := context.WithTimeout(cmd.Context(), shutdownTimeout)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/swaggo/swag v1.16.3-0.20230925065629-1460377e6729
 	github.com/volatiletech/null/v8 v8.1.2
 	go.hollow.sh/serverservice v0.16.1
-	go.hollow.sh/toolbox v0.6.1
+	go.hollow.sh/toolbox v0.6.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 	go.opentelemetry.io/otel v1.18.0
 	go.opentelemetry.io/otel/trace v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -719,6 +719,8 @@ go.hollow.sh/serverservice v0.16.1 h1:BlrwKOPim+RGqJ2Efz/CZvD/W2pvFkDfg9XI1AaQSW
 go.hollow.sh/serverservice v0.16.1/go.mod h1:Zr99vSFO++ZlDjEf9rtPWi3TiMgMswJCW3D6LIFmMDM=
 go.hollow.sh/toolbox v0.6.1 h1:3E6JofImSCe63XayczbGfDxIXUjmBziMBBmbwook8WA=
 go.hollow.sh/toolbox v0.6.1/go.mod h1:nl+5RDDyYY/+wukOUzHHX2mOyWKRjlTOXUcGxny+tns=
+go.hollow.sh/toolbox v0.6.2 h1:g0qKvo7rVgZ05dh7qxbAymPixumCd4MxVbq9gs90/3c=
+go.hollow.sh/toolbox v0.6.2/go.mod h1:nl+5RDDyYY/+wukOUzHHX2mOyWKRjlTOXUcGxny+tns=
 go.infratographer.com/x v0.3.7 h1:kkykoVtC8XrmvC4oZwHWa/15+dv9RhQHgSm8KoEb/Nc=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -31,6 +31,9 @@ const (
 	// ServerserviceStore identifies a serverservice store.
 	ServerserviceStore StoreKind = "serverservice"
 
+	// NATS is a NATS kv-based store
+	NATS StoreKind = "nats"
+
 	// NatsEventsBroker identifies a NATS events broker.
 	NatsEventBroker EventBrokerKind = "nats"
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -136,17 +136,9 @@ func New(opts ...Option) *http.Server {
 	}
 }
 
-// ping checks the server can reach its store repository
+// this is a placeholder for a more comprehensive readiness check
 func (s *Server) ping(c *gin.Context) {
-	if err := s.repository.Ping(c.Request.Context()); err != nil {
-		s.logger.Errorf("storage repository ping check failed: %s", err)
-		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"status": "DOWN",
-		})
-
-		return
-	}
-
+	// XXX: the repository Ping method was removed because it returns a nil error unconditionally
 	c.JSON(http.StatusOK, gin.H{
 		"status": "UP",
 	})

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -3,8 +3,10 @@ package store
 import "github.com/pkg/errors"
 
 var (
-	ErrServerNotFound     = errors.New("server not found")
-	ErrConditionExists    = errors.New("condition exists on server")
-	ErrConditionNotFound  = errors.New("condition not found")
-	ErrMalformedCondition = errors.New("condition data is invalid")
+	ErrServerNotFound       = errors.New("server not found")
+	ErrConditionExists      = errors.New("condition exists on server")
+	ErrConditionNotFound    = errors.New("condition not found")
+	ErrMalformedCondition   = errors.New("condition data is invalid")
+	ErrNoCreate             = errors.New("unable to create condition")
+	ErrConditionNotComplete = errors.New("condition is not complete") // can't delete
 )

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -2,11 +2,19 @@ package store
 
 import (
 	"context"
+	"net/url"
 
+	"github.com/coreos/go-oidc"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/metal-toolbox/conditionorc/internal/app"
 	"github.com/metal-toolbox/conditionorc/internal/model"
 	rctypes "github.com/metal-toolbox/rivets/condition"
+	sservice "go.hollow.sh/serverservice/pkg/api/v1"
+	"go.hollow.sh/toolbox/events"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -14,9 +22,6 @@ import (
 
 // NOTE: when updating this interface, run make gen-store-mock to make sure the mocks are updated.
 type Repository interface {
-	// Ping tests the repository is available.
-	Ping(ctx context.Context) error
-
 	// Get a condition set on a server.
 	// @serverID: required
 	// @conditionKind: required
@@ -31,9 +36,6 @@ type Repository interface {
 	// @conditionState: optional
 	List(ctx context.Context, serverID uuid.UUID, conditionState rctypes.State) ([]*rctypes.Condition, error)
 
-	ListServersWithCondition(ctx context.Context, conditionKind rctypes.Kind, conditionState rctypes.State) ([]*rctypes.ServerConditions, error)
-
-	// Create a condition on a server.
 	// @serverID: required
 	// @condition: required
 	Create(ctx context.Context, serverID uuid.UUID, condition *rctypes.Condition) error
@@ -51,11 +53,99 @@ type Repository interface {
 
 var ErrRepository = errors.New("storage repository error")
 
-func NewStore(ctx context.Context, config *app.Configuration, conditionDefs rctypes.Definitions, logger *logrus.Logger) (Repository, error) {
+func NewStore(config *app.Configuration, conditionDefs rctypes.Definitions,
+	logger *logrus.Logger, stream events.Stream) (Repository, error) {
+
+	ssOpts := &config.ServerserviceOptions
+	client, err := getServerServiceClient(ssOpts, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	switch config.StoreKind {
 	case model.ServerserviceStore:
-		return newServerserviceStore(ctx, &config.ServerserviceOptions, conditionDefs, logger)
+		return &ServerService{
+			config:               ssOpts,
+			conditionDefinitions: conditionDefs,
+			logger:               logger,
+			client:               client,
+		}, nil
+	case model.NATS:
+		return newNatsRepository(client, logger, stream)
 	default:
 		return nil, errors.Wrap(ErrRepository, "storage kind not implemented: "+string(config.StoreKind))
 	}
+}
+
+func getServerServiceClient(cfg *app.ServerserviceOptions, log *logrus.Logger) (*sserver.Client, error) {
+	var client *sservice.Client
+	var err error
+
+	if !cfg.DisableOAuth {
+		client, err = newClientWithOAuth(context.Background(), cfg, log)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		client, err = sservice.NewClientWithToken("fake", cfg.Endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}
+
+// returns a serverservice retryable http client with Otel and Oauth wrapped in
+func newClientWithOAuth(ctx context.Context, cfg *app.ServerserviceOptions, logger *logrus.Logger) (*sservice.Client, error) {
+	// init retryable http client
+	retryableClient := retryablehttp.NewClient()
+
+	// set retryable HTTP client to be the otel http client to collect telemetry
+	retryableClient.HTTPClient = otelhttp.DefaultClient
+
+	// disable default debug logging on the retryable client
+	if logger.Level < logrus.DebugLevel {
+		retryableClient.Logger = nil
+	} else {
+		retryableClient.Logger = logger
+	}
+
+	// setup oidc provider
+	provider, err := oidc.NewProvider(ctx, cfg.OidcIssuerEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	clientID := "conditionorc-api"
+
+	if cfg.OidcClientID != "" {
+		clientID = cfg.OidcClientID
+	}
+
+	// setup oauth configuration
+	oauthConfig := clientcredentials.Config{
+		ClientID:       clientID,
+		ClientSecret:   cfg.OidcClientSecret,
+		TokenURL:       provider.Endpoint().TokenURL,
+		Scopes:         cfg.OidcClientScopes,
+		EndpointParams: url.Values{"audience": []string{cfg.OidcAudienceEndpoint}},
+		// with this the oauth client spends less time identifying the client grant mechanism.
+		AuthStyle: oauth2.AuthStyleInParams,
+	}
+
+	// wrap OAuth transport, cookie jar in the retryable client
+	oAuthclient := oauthConfig.Client(ctx)
+
+	retryableClient.HTTPClient.Transport = oAuthclient.Transport
+	retryableClient.HTTPClient.Jar = oAuthclient.Jar
+
+	httpClient := retryableClient.StandardClient()
+	httpClient.Timeout = connectionTimeout
+
+	return sservice.NewClientWithToken(
+		cfg.OidcClientSecret,
+		cfg.Endpoint,
+		httpClient,
+	)
 }

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -81,13 +81,13 @@ func getServerServiceClient(ctx context.Context, cfg *app.ServerserviceOptions, 
 	var client *sservice.Client
 	var err error
 
-	if !cfg.DisableOAuth {
-		client, err = newClientWithOAuth(ctx, cfg, log)
+	if cfg.DisableOAuth {
+		client, err = sservice.NewClientWithToken("fake", cfg.Endpoint, nil)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		client, err = sservice.NewClientWithToken("fake", cfg.Endpoint, nil)
+		client, err = newClientWithOAuth(ctx, cfg, log)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -64,7 +64,7 @@ func NewStore(config *app.Configuration, conditionDefs rctypes.Definitions,
 
 	switch config.StoreKind {
 	case model.ServerserviceStore:
-		return &ServerService{
+		return &Serverservice{
 			config:               ssOpts,
 			conditionDefinitions: conditionDefs,
 			logger:               logger,
@@ -77,7 +77,7 @@ func NewStore(config *app.Configuration, conditionDefs rctypes.Definitions,
 	}
 }
 
-func getServerServiceClient(cfg *app.ServerserviceOptions, log *logrus.Logger) (*sserver.Client, error) {
+func getServerServiceClient(cfg *app.ServerserviceOptions, log *logrus.Logger) (*sservice.Client, error) {
 	var client *sservice.Client
 	var err error
 

--- a/internal/store/mock.go
+++ b/internal/store/mock.go
@@ -110,35 +110,6 @@ func (mr *MockRepositoryMockRecorder) List(ctx, serverID, conditionState interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockRepository)(nil).List), ctx, serverID, conditionState)
 }
 
-// ListServersWithCondition mocks base method.
-func (m *MockRepository) ListServersWithCondition(ctx context.Context, conditionKind condition.Kind, conditionState condition.State) ([]*condition.ServerConditions, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServersWithCondition", ctx, conditionKind, conditionState)
-	ret0, _ := ret[0].([]*condition.ServerConditions)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListServersWithCondition indicates an expected call of ListServersWithCondition.
-func (mr *MockRepositoryMockRecorder) ListServersWithCondition(ctx, conditionKind, conditionState interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServersWithCondition", reflect.TypeOf((*MockRepository)(nil).ListServersWithCondition), ctx, conditionKind, conditionState)
-}
-
-// Ping mocks base method.
-func (m *MockRepository) Ping(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ping", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Ping indicates an expected call of Ping.
-func (mr *MockRepositoryMockRecorder) Ping(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockRepository)(nil).Ping), ctx)
-}
-
 // Update mocks base method.
 func (m *MockRepository) Update(ctx context.Context, serverID uuid.UUID, condition *condition.Condition) error {
 	m.ctrl.T.Helper()

--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -1,0 +1,297 @@
+package store
+
+/* This file implements the store interface backed by a NATS KV bucket.
+   This bucket uses the server UUID as a key and uses the below-defined
+   conditionRecord as its data.
+*/
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/metal-toolbox/conditionorc/internal/metrics"
+	"github.com/metal-toolbox/conditionorc/internal/model"
+	rctypes "github.com/metal-toolbox/rivets/condition"
+	"github.com/nats-io/nats.go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	sservice "go.hollow.sh/serverservice/pkg/api/v1"
+	"go.hollow.sh/toolbox/events"
+	"go.hollow.sh/toolbox/events/pkg/kv"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var (
+	bucketName = "active-conditions"
+	bucketOpts = []kv.Option{
+		kv.WithDescription("tracking active conditions on servers"),
+		kv.WithTTL(10 * 24 * time.Hour), // XXX: we could keep more history here, but might need more storage
+	}
+)
+
+type natsStore struct {
+	client *sservice.Client
+	log    *logrus.Logger
+	bucket nats.KeyValue
+}
+
+type conditionRecord struct {
+	ID         uuid.UUID            `json:"id"`
+	State      rctypes.State        `json:"state"`
+	Conditions []*rctypes.Condition `json:"conditions"`
+}
+
+func (c conditionRecord) MustJSON() json.RawMessage {
+	byt, err := json.Marshal(&c)
+	if err != nil {
+		panic("bad condition record serialize")
+	}
+	return byt
+}
+
+func (c *conditionRecord) FromJSON(rm json.RawMessage) error {
+	return json.Unmarshal(rm, c)
+}
+
+func natsError(op string) {
+	metrics.DependencyError("nats-active-conditions", op)
+}
+
+func newNatsRepository(client *sservice.Client, log *logrus.Logger, stream events.Stream, replicaCount int) (*natsStore, error) {
+	evJS, ok := stream.(*events.NatsJetstream)
+	if !ok {
+		// play stupid games, win stupid prizes
+		panic("bad stream implementation")
+	}
+
+	kvOpts := bucketOpts
+	if replicaCount > 1 {
+		kvOpts = append(kvOpts, kv.WithReplicas(replicaCount))
+	}
+
+	kvHandle, err := kv.CreateOrBindKVBucket(evJS, bucketName, kvOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "binding active conditions bucket")
+	}
+	return &natsStore{
+		client: client,
+		log:    log,
+		bucket: kvHandle,
+	}, nil
+}
+
+// we must find an active condition with a kind that matches in order to successfully return
+// a condition here.
+func (n *natsStore) findConditionRecord(srvID uuid.UUID, kind rctypes.Kind) (*conditionRecord,
+	*rctypes.Condition, error) {
+	le := n.log.WithFields(logrus.Fields{
+		"serverID":      srvID.String(),
+		"conditionKind": kind,
+	})
+
+	kve, err := n.bucket.Get(srvID.String())
+	switch {
+	case err == nil:
+	case errors.Is(nats.ErrKeyNotFound, err):
+		le.Debug("no active condition for device")
+		return nil, nil, ErrConditionNotFound
+	default:
+		natsError("get")
+		le.WithError(err).Warn("looking up active condition")
+		return nil, nil, errors.Wrap(ErrRepository, err.Error())
+	}
+
+	var cr conditionRecord
+	if err := cr.FromJSON(kve.Value()); err != nil {
+		le.WithError(err).Warn("bad condition data")
+		return nil, nil, errors.Wrap(ErrRepository, err.Error())
+	}
+
+	var found *rctypes.Condition
+	for _, c := range cr.Conditions {
+		if c.Kind == kind {
+			// XXX: this assumes that there is only a single example of a given condition
+			// kind in a record. That is reasonable for current use-cases.
+			found = c
+			break
+		}
+	}
+
+	if found == nil {
+		le.WithField("conditionID", cr.ID.String()).Warn("condition record missing specified type")
+		return nil, nil, ErrConditionNotFound
+	}
+
+	return &cr, found, nil
+}
+
+// Get returns the active condition of the given Kind on the server.
+func (n *natsStore) Get(ctx context.Context, serverID uuid.UUID, kind rctypes.Kind) (*rctypes.Condition, error) {
+	_, span := otel.Tracer(pkgName).Start(ctx, "NatsStore.Get")
+	defer span.End()
+
+	_, condition, err := n.findConditionRecord(serverID, kind)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
+	if span.IsRecording() {
+		span.SetAttributes(attribute.Stringer("conditionID", condition.ID))
+	}
+
+	return condition, nil
+}
+
+// GetServer returns the facility for the requested server id.
+// XXX: this doesn't belong in this interface. We use it *only* to get a facility code.
+func (n *natsStore) GetServer(ctx context.Context, serverID uuid.UUID) (*model.Server, error) {
+	otelCtx, span := otel.Tracer(pkgName).Start(ctx, "NatsStore.GetServer")
+	defer span.End()
+
+	// list attributes on a server
+	obj, _, err := n.client.Get(otelCtx, serverID)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil, ErrServerNotFound
+		}
+
+		n.log.WithFields(logrus.Fields{
+			"serverID": serverID.String(),
+			"error":    err,
+			"method":   "GetServer",
+		}).Warn("error reaching serverservice")
+
+		serverServiceError("get-server")
+
+		return nil, errors.Wrap(ErrServerserviceQuery, err.Error())
+	}
+
+	return &model.Server{ID: obj.UUID, FacilityCode: obj.FacilityCode}, nil
+}
+
+// List is deprecated and is not implemented here
+func (n *natsStore) List(_ context.Context, _ uuid.UUID, _ rctypes.State) ([]*rctypes.Condition, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// Create a condition on a server.
+// @id: required
+// @condition: required
+//
+// Note: its upto the caller to validate the condition payload and to check any existing condition before creating.
+func (n *natsStore) Create(ctx context.Context, serverID uuid.UUID, condition *rctypes.Condition) error {
+	_, span := otel.Tracer(pkgName).Start(ctx, "NatsStore.Create")
+	defer span.End()
+
+	le := n.log.WithFields(logrus.Fields{
+		"serverID":      serverID.String(),
+		"conditionKind": condition.Kind,
+		"conditionID":   condition.ID.String(),
+	})
+
+	cr := conditionRecord{
+		ID:    condition.ID,
+		State: rctypes.Pending,
+		Conditions: []*rctypes.Condition{
+			condition,
+		},
+	}
+
+	_, err := n.bucket.Create(serverID.String(), cr.MustJSON())
+	if err != nil {
+		natsError("create")
+		span.RecordError(err)
+		le.WithError(err).Warn("writing condition to storage")
+	}
+	return err
+}
+
+// Update a condition on a server.
+// @id: required
+// @condition: required
+//
+// Note: it's up to the caller to validate the condition update payload. The condition to update must
+// exist, and it must be in a non-final state. The existing condition will be replaced by the incoming
+// parameter. If applicable, the state of the conditionRecord will be updated as well.
+func (n *natsStore) Update(ctx context.Context, serverID uuid.UUID, condition *rctypes.Condition) error {
+	_, span := otel.Tracer(pkgName).Start(ctx, "NatsStore.Update")
+	defer span.End()
+
+	le := n.log.WithFields(logrus.Fields{
+		"serverID":      serverID.String(),
+		"conditionKind": condition.Kind,
+		"conditionID":   condition.ID.String(),
+	})
+
+	cr, orig, err := n.findConditionRecord(serverID, condition.Kind)
+	if err != nil {
+		span.RecordError(err)
+		le.WithError(err).Warn("condition lookup failure on update")
+		return err
+	}
+
+	cr.State = condition.State
+
+	for idx, cond := range cr.Conditions {
+		i := idx
+		c := cond
+		if c == orig {
+			cr.Conditions[i] = condition
+			break
+		}
+	}
+
+	_, err = n.bucket.Put(serverID.String(), cr.MustJSON())
+	if err != nil {
+		natsError("update")
+		span.RecordError(err)
+		le.WithError(err).Warn("writing condition record on update")
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes a condition from being associated with a server. It adheres to the notion that
+// deletes are idempotent; requesting the deletion of a non-existent condition is not an error on
+// the part of this component. This enables repetition of a failed step that composes some
+// operations that succeeded and some that need to be retried.
+func (n *natsStore) Delete(ctx context.Context, serverID uuid.UUID, kind rctypes.Kind) error {
+	_, span := otel.Tracer(pkgName).Start(ctx, "NatsStore.Delete")
+	defer span.End()
+
+	le := n.log.WithFields(logrus.Fields{
+		"serverID":      serverID.String(),
+		"conditionKind": kind,
+	})
+
+	cr, _, err := n.findConditionRecord(serverID, kind)
+
+	if errors.Is(err, ErrConditionNotFound) {
+		le.Info("request to delete non-existent condition")
+		return nil
+	}
+
+	if err != nil {
+		span.RecordError(err)
+		le.WithError(err).Warn("condition lookup failure on delete")
+		return err
+	}
+
+	if !rctypes.StateIsComplete(cr.State) {
+		return ErrConditionNotComplete
+	}
+
+	err = n.bucket.Delete(serverID.String())
+	if err != nil {
+		natsError("delete")
+		span.RecordError(err)
+		le.WithError(err).Warn("deleting condition record")
+	}
+	return err
+}

--- a/internal/store/nats_test.go
+++ b/internal/store/nats_test.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	rctypes "github.com/metal-toolbox/rivets/condition"
+
+	"github.com/google/uuid"
+	"github.com/nats-io/nats-server/v2/server"
+	srvtest "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.hollow.sh/toolbox/events"
+	"go.hollow.sh/toolbox/events/pkg/kv"
+)
+
+var (
+	nc     *nats.Conn
+	js     nats.JetStreamContext
+	evJS   *events.NatsJetstream
+	logger *logrus.Logger
+)
+
+func init() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+}
+
+func startJetStreamServer() *server.Server {
+	opts := srvtest.DefaultTestOptions
+	opts.Port = -1
+	opts.JetStream = true
+	return srvtest.RunServer(&opts)
+}
+
+func jetStreamContext(s *server.Server) (*nats.Conn, nats.JetStreamContext) {
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		logger.Fatalf("connect => %v", err)
+	}
+	js, err := nc.JetStream(nats.MaxWait(10 * time.Second))
+	if err != nil {
+		logger.Fatalf("JetStream => %v", err)
+	}
+	return nc, js
+}
+
+func shutdownJetStream(s *server.Server) {
+	var sd string
+	if config := s.JetStreamConfig(); config != nil {
+		sd = config.StoreDir
+	}
+	s.Shutdown()
+	if sd != "" {
+		if err := os.RemoveAll(sd); err != nil {
+			logger.Fatalf("Unable to remove storage %q: %v", sd, err)
+		}
+	}
+	s.WaitForShutdown()
+}
+
+// do some one-time setup
+func TestMain(m *testing.M) {
+	logger = logrus.New()
+
+	srv := startJetStreamServer()
+	defer shutdownJetStream(srv)
+	nc, js = jetStreamContext(srv) // nc is closed on evJS.Close(), js needs no cleanup
+	evJS = events.NewJetstreamFromConn(nc)
+	defer evJS.Close()
+
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+func TestCRUD(t *testing.T) {
+	serverID := uuid.New()
+
+	kind := rctypes.Kind("test-kind")
+
+	condition := &rctypes.Condition{
+		ID:    uuid.New(),
+		Kind:  kind,
+		State: rctypes.Pending,
+	}
+
+	logger := &logrus.Logger{}
+
+	bucket, err := kv.CreateOrBindKVBucket(evJS, bucketName)
+	require.NoError(t, err, "setup NATS kv")
+
+	store := &natsStore{
+		bucket: bucket,
+		log:    logger,
+	}
+
+	// look for a condition in an empty bucket and find nothing
+	_, err = store.Get(context.TODO(), serverID, kind)
+	require.ErrorIs(t, err, ErrConditionNotFound)
+
+	// add a condition
+	err = store.Create(context.TODO(), serverID, condition)
+	require.NoError(t, err)
+
+	// find the new condition
+	c, err := store.Get(context.TODO(), serverID, kind)
+	require.NoError(t, err)
+	require.Equal(t, condition.ID.String(), c.ID.String())
+
+	// update the condition
+	condition.State = rctypes.Active
+	err = store.Update(context.TODO(), serverID, condition)
+	require.NoError(t, err)
+
+	// read the new condition
+	c, err = store.Get(context.TODO(), serverID, kind)
+	require.NoError(t, err)
+	require.Equal(t, condition.State, c.State)
+
+	// OK, get rid of it
+	err = store.Delete(context.TODO(), serverID, kind)
+	require.ErrorIs(t, err, ErrConditionNotComplete)
+
+	condition.State = rctypes.Succeeded
+	err = store.Update(context.TODO(), serverID, condition)
+	require.NoError(t, err)
+
+	err = store.Delete(context.TODO(), serverID, kind)
+	require.NoError(t, err)
+
+	// And now it's not here anymore
+	_, err = store.Get(context.TODO(), serverID, kind)
+	require.ErrorIs(t, err, ErrConditionNotFound)
+}


### PR DESCRIPTION
#### What does this PR do
Add a NATS kv-based store for conditions. This simplifies tracking active conditions and reduces condition-api's and condition-orchestrator's dependence on server-service.