### PR TITLE
remove client support for dead apis

### DIFF
--- a/pkg/api/v1/client/client.go
+++ b/pkg/api/v1/client/client.go
@@ -78,27 +78,8 @@ func (c *Client) ServerConditionGet(ctx context.Context, serverID uuid.UUID, con
 	return c.get(ctx, path)
 }
 
-func (c *Client) ServerConditionList(ctx context.Context, serverID uuid.UUID, conditionState rctypes.State) (*v1types.ServerResponse, error) {
-	path := fmt.Sprintf("servers/%s/state/%s", serverID.String(), conditionState)
-
-	return c.get(ctx, path)
-}
-
 func (c *Client) ServerConditionCreate(ctx context.Context, serverID uuid.UUID, conditionKind rctypes.Kind, conditionCreate v1types.ConditionCreate) (*v1types.ServerResponse, error) {
 	path := fmt.Sprintf("servers/%s/condition/%s", serverID.String(), conditionKind)
 
 	return c.post(ctx, path, conditionCreate)
-}
-
-//nolint:gocritic // 80 bytes for v1types.ConditionUpdate is big, but not *huge*
-func (c *Client) ServerConditionUpdate(ctx context.Context, serverID uuid.UUID, conditionKind rctypes.Kind, conditionUpdate v1types.ConditionUpdate) (*v1types.ServerResponse, error) {
-	path := fmt.Sprintf("servers/%s/condition/%s", serverID.String(), conditionKind)
-
-	return c.put(ctx, path, conditionUpdate)
-}
-
-func (c *Client) ServerConditionDelete(ctx context.Context, serverID uuid.UUID, conditionKind rctypes.Kind) (*v1types.ServerResponse, error) {
-	path := fmt.Sprintf("servers/%s/condition/%s", serverID.String(), conditionKind)
-
-	return c.delete(ctx, path)
 }

--- a/pkg/api/v1/client/requests.go
+++ b/pkg/api/v1/client/requests.go
@@ -28,25 +28,6 @@ func (c *Client) get(ctx context.Context, path string) (*v1types.ServerResponse,
 	return c.do(req)
 }
 
-func (c *Client) put(ctx context.Context, path string, body interface{}) (*v1types.ServerResponse, error) {
-	requestURL, err := url.Parse(fmt.Sprintf("%s%s/%s", c.serverAddress, routes.PathPrefix, path))
-	if err != nil {
-		return nil, Error{Cause: err.Error()}
-	}
-
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return nil, Error{Cause: "error in PUT JSON payload: " + err.Error()}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL.String(), bytes.NewReader(payload))
-	if err != nil {
-		return nil, Error{Cause: "error in PUT request" + err.Error()}
-	}
-
-	return c.do(req)
-}
-
 func (c *Client) post(ctx context.Context, path string, body interface{}) (*v1types.ServerResponse, error) {
 	requestURL, err := url.Parse(fmt.Sprintf("%s%s/%s", c.serverAddress, routes.PathPrefix, path))
 	if err != nil {
@@ -61,20 +42,6 @@ func (c *Client) post(ctx context.Context, path string, body interface{}) (*v1ty
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(payload))
 	if err != nil {
 		return nil, Error{Cause: "error in POST request" + err.Error()}
-	}
-
-	return c.do(req)
-}
-
-func (c *Client) delete(ctx context.Context, path string) (*v1types.ServerResponse, error) {
-	requestURL, err := url.Parse(fmt.Sprintf("%s%s/%s", c.serverAddress, routes.PathPrefix, path))
-	if err != nil {
-		return nil, Error{Cause: err.Error()}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL.String(), http.NoBody)
-	if err != nil {
-		return nil, Error{Cause: "error in DELETE request" + err.Error()}
 	}
 
 	return c.do(req)


### PR DESCRIPTION
#### What does this PR do

This catches the client up with the current state of the API handlers.