### PR TITLE
Improve server_enroll error handling

### DIFF
--- a/internal/fleetdb/fleetdb.go
+++ b/internal/fleetdb/fleetdb.go
@@ -57,9 +57,7 @@ func (s *fleetDBImpl) AddServer(ctx context.Context, serverID uuid.UUID, facilit
 			server := sservice.Server{UUID: serverID, Name: serverID.String(), FacilityCode: facilityCode}
 			_, err := s.client.Delete(ctx, server)
 			if err != nil {
-				s.logger.WithFields(logrus.Fields{
-					"error": err,
-				}).Warningf("server enroll failed to rollback server")
+				s.logger.WithError(err).Warning("server enroll failed to rollback server")
 				return err
 			}
 		}
@@ -67,9 +65,7 @@ func (s *fleetDBImpl) AddServer(ctx context.Context, serverID uuid.UUID, facilit
 		if createStatus.credentialCreated {
 			_, err := s.client.DeleteCredential(ctx, serverID, secretSlug)
 			if err != nil {
-				s.logger.WithFields(logrus.Fields{
-					"error": err,
-				}).Warningf("server enroll failed to rollback credential")
+				s.logger.WithError(err).Warning("server enroll failed to rollback credential")
 				return err
 			}
 		}
@@ -77,9 +73,7 @@ func (s *fleetDBImpl) AddServer(ctx context.Context, serverID uuid.UUID, facilit
 		if createStatus.attributesCreated {
 			_, err := s.client.DeleteAttributes(ctx, serverID, rservice.ServerAttributeNSBmcAddress)
 			if err != nil {
-				s.logger.WithFields(logrus.Fields{
-					"error": err,
-				}).Warningf("server enroll failed to rollback attributes")
+				s.logger.WithError(err).Warning("server enroll failed to rollback attributes")
 				return err
 			}
 		}

--- a/internal/fleetdb/fleetdb.go
+++ b/internal/fleetdb/fleetdb.go
@@ -57,6 +57,9 @@ func (s *fleetDBImpl) AddServer(ctx context.Context, serverID uuid.UUID, facilit
 			server := sservice.Server{UUID: serverID, Name: serverID.String(), FacilityCode: facilityCode}
 			_, err := s.client.Delete(ctx, server)
 			if err != nil {
+				s.logger.WithFields(logrus.Fields{
+					"error": err,
+				}).Warningf("server enroll failed to rollback server")
 				return err
 			}
 		}
@@ -64,6 +67,9 @@ func (s *fleetDBImpl) AddServer(ctx context.Context, serverID uuid.UUID, facilit
 		if createStatus.credentialCreated {
 			_, err := s.client.DeleteCredential(ctx, serverID, secretSlug)
 			if err != nil {
+				s.logger.WithFields(logrus.Fields{
+					"error": err,
+				}).Warningf("server enroll failed to rollback credential")
 				return err
 			}
 		}
@@ -71,6 +77,9 @@ func (s *fleetDBImpl) AddServer(ctx context.Context, serverID uuid.UUID, facilit
 		if createStatus.attributesCreated {
 			_, err := s.client.DeleteAttributes(ctx, serverID, rservice.ServerAttributeNSBmcAddress)
 			if err != nil {
+				s.logger.WithFields(logrus.Fields{
+					"error": err,
+				}).Warningf("server enroll failed to rollback attributes")
 				return err
 			}
 		}

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -183,6 +183,7 @@ func (r *Routes) serverEnroll(c *gin.Context) (int, *v1types.ServerResponse) {
 	inventoryParams, err := json.Marshal(inventoryArgs)
 	if err != nil {
 		_ = rollback()
+		r.logger.WithError(err).Warning("bad condition inventoryParams serialize")
 		panic(err)
 	}
 	conditionCreate.Parameters = inventoryParams

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -182,10 +182,8 @@ func (r *Routes) serverEnroll(c *gin.Context) (int, *v1types.ServerResponse) {
 	}
 	inventoryParams, err := json.Marshal(inventoryArgs)
 	if err != nil {
-		rollbackErr := rollback()
-		return http.StatusBadRequest, &v1types.ServerResponse{
-			Message: err.Error() + fmt.Sprintf("server rollback err: %v", rollbackErr),
-		}
+		_ = rollback()
+		panic(err)
 	}
 	conditionCreate.Parameters = inventoryParams
 	newCondition := conditionCreate.NewCondition(rctypes.Inventory)


### PR DESCRIPTION
- Replace error response with panic to catch alert faster, as is suggested in https://github.com/metal-toolbox/conditionorc/pull/137/files#r1388602247
- Dump warning logs when fail to rollback server. It may be easier for us to query logs and tracking leaked servers.
