### PR TITLE
Support Server Delete

### DIFF
--- a/internal/fleetdb/fleetdb.go
+++ b/internal/fleetdb/fleetdb.go
@@ -142,3 +142,12 @@ func (s *fleetDBImpl) GetServer(ctx context.Context, serverID uuid.UUID) (*model
 
 	return &model.Server{ID: obj.UUID, FacilityCode: obj.FacilityCode}, nil
 }
+
+// DeleteServer creates a server record in FleetDB
+func (s *fleetDBImpl) DeleteServer(ctx context.Context, serverID uuid.UUID) error {
+	otelCtx, span := otel.Tracer(pkgName).Start(ctx, "FleetDB.GetServer")
+	defer span.End()
+
+	_, err := s.client.Delete(otelCtx, sservice.Server{UUID: serverID})
+	return err
+}

--- a/internal/fleetdb/interface.go
+++ b/internal/fleetdb/interface.go
@@ -26,6 +26,8 @@ type FleetDB interface {
 	// Get Server attributes.
 	// @serverID: required
 	GetServer(ctx context.Context, serverID uuid.UUID) (*model.Server, error)
+	// DeleteServer
+	DeleteServer(ctx context.Context, serverID uuid.UUID) error
 }
 
 func NewFleetDBClient(ctx context.Context, config *app.Configuration, conditionDefs rctypes.Definitions,

--- a/internal/fleetdb/mock.go
+++ b/internal/fleetdb/mock.go
@@ -51,6 +51,20 @@ func (mr *MockFleetDBMockRecorder) AddServer(ctx, serverID, facilityCode, bmcAdd
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddServer", reflect.TypeOf((*MockFleetDB)(nil).AddServer), ctx, serverID, facilityCode, bmcAddr, bmcUser, bmcPass)
 }
 
+// DeleteServer mocks base method.
+func (m *MockFleetDB) DeleteServer(ctx context.Context, serverID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteServer", ctx, serverID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteServer indicates an expected call of DeleteServer.
+func (mr *MockFleetDBMockRecorder) DeleteServer(ctx, serverID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServer", reflect.TypeOf((*MockFleetDB)(nil).DeleteServer), ctx, serverID)
+}
+
 // GetServer mocks base method.
 func (m *MockFleetDB) GetServer(ctx context.Context, serverID uuid.UUID) (*model.Server, error) {
 	m.ctrl.T.Helper()

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -98,7 +98,7 @@ func (r *Routes) serverConditionCreate(c *gin.Context) (int, *v1types.ServerResp
 	facilityCode, err := r.serverFacilityCode(otelCtx, serverID)
 	if err != nil {
 		return http.StatusInternalServerError, &v1types.ServerResponse{
-			Message: "error looking up facility on non-existence server: " + err.Error(),
+			Message: "facility lookup error: " + err.Error(),
 		}
 	}
 
@@ -155,8 +155,10 @@ func (r *Routes) serverDelete(c *gin.Context) (int, *v1types.ServerResponse) {
 	}
 
 	if err := r.fleetDBClient.DeleteServer(c.Request.Context(), serverID); err != nil {
-		return http.StatusInternalServerError, &v1types.ServerResponse{
-			Message: err.Error(),
+		if !strings.Contains(err.Error(), "404") {
+			return http.StatusInternalServerError, &v1types.ServerResponse{
+				Message: err.Error(),
+			}
 		}
 	}
 

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -384,6 +384,221 @@ func TestAddServer(t *testing.T) {
 }
 
 // nolint:gocyclo // cyclomatic tests are cyclomatic
+func TestDeleteServer(t *testing.T) {
+	repository, fleetDBClient, _, server, err := setupTestServer(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockServerID := uuid.New()
+	testcases := []struct {
+		name              string
+		mockStore         func(r *store.MockRepository)
+		mockFleetDBClient func(f *fleetdb.MockFleetDB)
+		request           func(t *testing.T) *http.Request
+		assertResponse    func(t *testing.T, r *httptest.ResponseRecorder)
+	}{
+		{
+			"delete server success",
+			// mock repository
+			func(r *store.MockRepository) {
+				// create condition query
+				r.EXPECT().
+					GetActiveCondition(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(nil, nil).
+					Times(1)
+			},
+			func(r *fleetdb.MockFleetDB) {
+				// lookup for an existing condition
+				r.EXPECT().
+					DeleteServer(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(nil). // no condition exists
+					Times(1)
+			},
+			func(t *testing.T) *http.Request {
+				url := fmt.Sprintf("/api/v1/serverDelete/%v", mockServerID)
+				request, err := http.NewRequestWithContext(context.TODO(), http.MethodDelete, url, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return request
+			},
+			func(t *testing.T, r *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, r.Code)
+			},
+		},
+		{
+			"invalid ID",
+			// mock repository
+			func(r *store.MockRepository) {
+				// create condition query
+				r.EXPECT().
+					GetActiveCondition(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(&rctypes.Condition{}, nil).
+					Times(0)
+			},
+			func(r *fleetdb.MockFleetDB) {
+				// lookup for an existing condition
+				r.EXPECT().
+					DeleteServer(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(nil). // no condition exists
+					Times(0)
+			},
+			func(t *testing.T) *http.Request {
+				url := fmt.Sprintf("/api/v1/serverDelete/%v", "invalidID")
+				request, err := http.NewRequestWithContext(context.TODO(), http.MethodDelete, url, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return request
+			},
+			func(t *testing.T, r *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusBadRequest, r.Code)
+			},
+		},
+		{
+			"active condition",
+			// mock repository
+			func(r *store.MockRepository) {
+				// create condition query
+				r.EXPECT().
+					GetActiveCondition(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(&rctypes.Condition{}, nil).
+					Times(1)
+			},
+			func(r *fleetdb.MockFleetDB) {
+				// lookup for an existing condition
+				r.EXPECT().
+					DeleteServer(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(nil). // no condition exists
+					Times(0)
+			},
+			func(t *testing.T) *http.Request {
+				url := fmt.Sprintf("/api/v1/serverDelete/%v", mockServerID)
+				request, err := http.NewRequestWithContext(context.TODO(), http.MethodDelete, url, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return request
+			},
+			func(t *testing.T, r *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusBadRequest, r.Code)
+			},
+		},
+		{
+			"check active condition error",
+			// mock repository
+			func(r *store.MockRepository) {
+				// create condition query
+				r.EXPECT().
+					GetActiveCondition(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(nil, fmt.Errorf("fake check condition error")).
+					Times(1)
+			},
+			func(r *fleetdb.MockFleetDB) {
+				// lookup for an existing condition
+				r.EXPECT().
+					DeleteServer(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(fmt.Errorf("fake delete error")). // no condition exists
+					Times(0)
+			},
+			func(t *testing.T) *http.Request {
+				url := fmt.Sprintf("/api/v1/serverDelete/%v", mockServerID)
+				request, err := http.NewRequestWithContext(context.TODO(), http.MethodDelete, url, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return request
+			},
+			func(t *testing.T, r *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusServiceUnavailable, r.Code)
+			},
+		},
+		{
+			"delete error",
+			// mock repository
+			func(r *store.MockRepository) {
+				// create condition query
+				r.EXPECT().
+					GetActiveCondition(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(nil, nil).
+					Times(1)
+			},
+			func(r *fleetdb.MockFleetDB) {
+				// lookup for an existing condition
+				r.EXPECT().
+					DeleteServer(
+						gomock.Any(),
+						gomock.Eq(mockServerID),
+					).
+					Return(fmt.Errorf("fake delete error")). // no condition exists
+					Times(1)
+			},
+			func(t *testing.T) *http.Request {
+				url := fmt.Sprintf("/api/v1/serverDelete/%v", mockServerID)
+				request, err := http.NewRequestWithContext(context.TODO(), http.MethodDelete, url, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return request
+			},
+			func(t *testing.T, r *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusInternalServerError, r.Code)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.mockStore != nil {
+				tc.mockStore(repository)
+			}
+
+			if tc.mockFleetDBClient != nil {
+				tc.mockFleetDBClient(fleetDBClient)
+			}
+
+			recorder := httptest.NewRecorder()
+			server.ServeHTTP(recorder, tc.request(t))
+
+			tc.assertResponse(t, recorder)
+		})
+	}
+}
+
+// nolint:gocyclo // cyclomatic tests are cyclomatic
 func TestAddServerRollback(t *testing.T) {
 	repository, fleetDBClient, stream, server, err := setupTestServer(t)
 	if err != nil {

--- a/pkg/api/v1/routes/routes.go
+++ b/pkg/api/v1/routes/routes.go
@@ -138,7 +138,9 @@ func (r *Routes) composeAuthHandler(scopes []string) gin.HandlerFunc {
 func (r *Routes) Routes(g *gin.RouterGroup) {
 	if r.enableServerEnroll {
 		serverEnroll := g.Group("/serverEnroll")
-		serverEnroll.POST("/:uuid", r.composeAuthHandler(createScopes("server-enroll")), wrapAPICall(r.serverEnroll))
+		serverEnroll.POST("/:uuid", r.composeAuthHandler(createScopes("server")), wrapAPICall(r.serverEnroll))
+		serverDelete := g.Group("/serverDelete")
+		serverDelete.DELETE("/:uuid", r.composeAuthHandler(createScopes("server")), wrapAPICall(r.serverDelete))
 		// Create a new server ID when uuid is not provided.
 		serverEnroll.POST("/", r.composeAuthHandler(createScopes("server-enroll")), wrapAPICall(r.serverEnroll))
 	}

--- a/pkg/api/v1/routes/routes.go
+++ b/pkg/api/v1/routes/routes.go
@@ -142,7 +142,7 @@ func (r *Routes) Routes(g *gin.RouterGroup) {
 		serverDelete := g.Group("/serverDelete")
 		serverDelete.DELETE("/:uuid", r.composeAuthHandler(createScopes("server")), wrapAPICall(r.serverDelete))
 		// Create a new server ID when uuid is not provided.
-		serverEnroll.POST("/", r.composeAuthHandler(createScopes("server-enroll")), wrapAPICall(r.serverEnroll))
+		serverEnroll.POST("/", r.composeAuthHandler(createScopes("server")), wrapAPICall(r.serverEnroll))
 	}
 
 	servers := g.Group("/servers/:uuid")


### PR DESCRIPTION
Support `DeleteServer`.

New API: `/api/v1/serverDelete/{$uuid}`

**Tested in sandbox**
Existing Server
```
                 id                  |                 name                 | facility_code |          created_at           |          updated_at           |          deleted_at
---------------------------------------+--------------------------------------+---------------+-------------------------------+-------------------------------+--------------------------------
b3744970-47a0-4261-abd5-de19d7f7c6bd | b3744970-47a0-4261-abd5-de19d7f7c6bd | sandbox       | 2023-11-17 04:49:52.082456+00 | 2023-11-17 04:49:52.082456+00 | NULL
```

First Delete
```
$ curl -i -X DELETE 'localhost:9001/api/v1/serverDelete/b3744970-47a0-4261-abd5-de19d7f7c6bd'
HTTP/1.1 200 OK
...
{"message":"server detele","records":{"serverID":"b3744970-47a0-4261-abd5-de19d7f7c6bd"}}
```
```
                 id                  |                 name                 | facility_code |          created_at           |          updated_at           |          deleted_at
---------------------------------------+--------------------------------------+---------------+-------------------------------+-------------------------------+--------------------------------
b3744970-47a0-4261-abd5-de19d7f7c6bd | b3744970-47a0-4261-abd5-de19d7f7c6bd | sandbox       | 2023-11-17 04:49:52.082456+00 | 2023-11-17 04:49:52.082456+00 | 2023-11-26 22:36:12.538992+00
```

Second Delete
```
$ curl -i -X DELETE 'localhost:9001/api/v1/serverDelete/b3744970-47a0-4261-abd5-de19d7f7c6bd'
HTTP/1.1 500 Internal Server Error
...
{"message":"hollow client received a server error - response code: 404, message: resource not found, details: sql: no rows in result set"}
```

Discuss:
For the second delete, we can return `404` to match server service error message.
Or use `500` referring the error comes from the server.
I don't have preference about it.
