### PR TITLE
Vc/multi condition

### DIFF
--- a/cmd/orchestrator.go
+++ b/cmd/orchestrator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/metal-toolbox/conditionorc/internal/orchestrator"
 	"github.com/metal-toolbox/conditionorc/internal/orchestrator/notify"
 	"github.com/metal-toolbox/conditionorc/internal/store"
+	"github.com/metal-toolbox/conditionorc/internal/version"
 	"github.com/spf13/cobra"
 	"go.hollow.sh/toolbox/events"
 )
@@ -79,6 +80,8 @@ var cmdOrchestrator = &cobra.Command{
 				Info("configuring status KV support")
 			options = append(options, orchestrator.WithReplicas(app.Config.NatsOptions.KVReplicationFactor))
 		}
+
+		app.Logger.Info(version.Current().String())
 
 		orc := orchestrator.New(options...)
 		orc.Run(ctx)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/metal-toolbox/conditionorc/internal/model"
 	"github.com/metal-toolbox/conditionorc/internal/server"
 	"github.com/metal-toolbox/conditionorc/internal/store"
+	"github.com/metal-toolbox/conditionorc/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.hollow.sh/toolbox/events"
@@ -77,6 +78,8 @@ var cmdServer = &cobra.Command{
 		} else {
 			app.Logger.Info("OIDC disabled")
 		}
+
+		app.Logger.Info(version.Current().String())
 
 		srv := server.New(options...)
 		go func() {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-retryablehttp v0.7.4
-	github.com/metal-toolbox/rivets v0.0.0-20231020103738-10fc2993b885
+	github.com/metal-toolbox/rivets v0.1.0
 	github.com/nats-io/nats-server/v2 v2.10.4
 	github.com/nats-io/nats.go v1.31.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/metal-toolbox/flasher v0.2.7 h1:+N7jbf2ceAqWj/WY1oeZN+bih3SIGTsBPUP3V
 github.com/metal-toolbox/flasher v0.2.7/go.mod h1:xSdUh74ZBS6PQvLJus+NFkEg6bnr8qcq10U8VDP6coc=
 github.com/metal-toolbox/rivets v0.0.0-20231020103738-10fc2993b885 h1:mpJZhvW/Mi1pclg7OhhRVRBlXKl2eUQ6HlgVfTcQ2Bw=
 github.com/metal-toolbox/rivets v0.0.0-20231020103738-10fc2993b885/go.mod h1:QlGp4NUmXkSa8lhm/fFlH845kamwiOM7kiIsigVxWlg=
+github.com/metal-toolbox/rivets v0.1.0 h1:lS4Sz3KT9cfZ5TmEdwB4xBUnGZxwcjaa+rRHVGuZi+E=
+github.com/metal-toolbox/rivets v0.1.0/go.mod h1:QlGp4NUmXkSa8lhm/fFlH845kamwiOM7kiIsigVxWlg=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +29,7 @@ var (
 	errKeyFormat        = errors.New("malformed update key")
 	errConditionID      = errors.New("bad condition uuid")
 	errInvalidState     = errors.New("invalid condition state")
+	errCompleteEvent    = errors.New("unable to complete event")
 	staleEventThreshold = 30 * time.Minute
 	reconcilerCadence   = 10 * time.Minute
 	failedByReconciler  = []byte(`{ "msg": "worker failed processing this event" }`)
@@ -283,9 +285,33 @@ func (o *Orchestrator) eventUpdate(ctx context.Context, evt *v1types.ConditionUp
 	}
 
 	if rctypes.StateIsComplete(evt.ConditionUpdate.State) {
-		err := status.DeleteCondition(evt.Kind, o.facility, evt.ConditionUpdate.ConditionID.String())
+		active, err := o.repository.GetActiveCondition(ctx, evt.ConditionUpdate.ServerID)
 		if err != nil {
-			return errors.Wrap(err, "deleting event KV data")
+			o.logger.WithError(err).WithFields(logrus.Fields{
+				"condition.id": evt.ConditionUpdate.ConditionID,
+				"server.id":    evt.ConditionUpdate.ServerID,
+			}).Warn("retrieving next active condition")
+			return errors.Wrap(errCompleteEvent, err.Error())
+		}
+		// seeing as we only *just* completed this event it's hard to believe we'd
+		// lose the race to publish the next one, but it's possible I suppose.
+		if active != nil && active.State == rctypes.Pending {
+			byt := active.MustBytes()
+			subject := fmt.Sprintf("%s.servers.%s", o.facility, active.Kind)
+			err := o.streamBroker.Publish(ctx, subject, byt)
+			if err != nil {
+				o.logger.WithError(err).WithFields(logrus.Fields{
+					"condition.id":   active.ID,
+					"server.id":      evt.ConditionUpdate.ServerID,
+					"condition.kind": active.Kind,
+				}).Warn("publishing next active condition")
+				return errors.Wrap(errCompleteEvent, err.Error())
+			}
+			o.logger.WithFields(logrus.Fields{
+				"condition.id":   active.ID,
+				"server.id":      evt.ConditionUpdate.ServerID,
+				"condition.kind": active.Kind,
+			}).Debug("published next condition in chain")
 		}
 	}
 

--- a/internal/orchestrator/updates_test.go
+++ b/internal/orchestrator/updates_test.go
@@ -131,7 +131,9 @@ func TestEventNeedsReconciliation(t *testing.T) {
 	}
 
 	evt := &v1types.ConditionUpdateEvent{
-		UpdatedAt: time.Now(),
+		ConditionUpdate: v1types.ConditionUpdate{
+			UpdatedAt: time.Now(),
+		},
 	}
 
 	require.False(t, o.eventNeedsReconciliation(evt))

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -39,11 +39,6 @@ type Repository interface {
 	// @serverID: required
 	// @condition: required
 	Update(ctx context.Context, serverID uuid.UUID, condition *rctypes.Condition) error
-
-	// Delete a condition from a server.
-	// @serverID: required
-	// @conditionKind: required
-	Delete(ctx context.Context, serverID uuid.UUID, conditionKind rctypes.Kind) error
 }
 
 var (

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -30,6 +30,11 @@ type Repository interface {
 	// @condition: required
 	Create(ctx context.Context, serverID uuid.UUID, condition *rctypes.Condition) error
 
+	// Create a condition record that encapsulates a unit of work encompassing multiple conditions
+	// If you create a condition record with 0 conditions, you don't actually create anything, but
+	// no error is returned.
+	CreateMultiple(ctx context.Context, serverID uuid.UUID, conditions ...*rctypes.Condition) error
+
 	// Update a condition on a server
 	// @serverID: required
 	// @condition: required
@@ -42,8 +47,9 @@ type Repository interface {
 }
 
 var (
-	pkgName       = "internal/store"
-	ErrRepository = errors.New("storage repository error")
+	pkgName            = "internal/store"
+	ErrRepository      = errors.New("storage repository error")
+	ErrActiveCondition = errors.New("server has an active condition")
 )
 
 func NewStore(config *app.Configuration, logger *logrus.Logger, stream events.Stream) (Repository, error) {

--- a/internal/store/mock.go
+++ b/internal/store/mock.go
@@ -50,6 +50,25 @@ func (mr *MockRepositoryMockRecorder) Create(ctx, serverID, condition interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRepository)(nil).Create), ctx, serverID, condition)
 }
 
+// CreateMultiple mocks base method.
+func (m *MockRepository) CreateMultiple(ctx context.Context, serverID uuid.UUID, conditions ...*condition.Condition) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, serverID}
+	for _, a := range conditions {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateMultiple", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateMultiple indicates an expected call of CreateMultiple.
+func (mr *MockRepositoryMockRecorder) CreateMultiple(ctx, serverID interface{}, conditions ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, serverID}, conditions...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMultiple", reflect.TypeOf((*MockRepository)(nil).CreateMultiple), varargs...)
+}
+
 // Delete mocks base method.
 func (m *MockRepository) Delete(ctx context.Context, serverID uuid.UUID, conditionKind condition.Kind) error {
 	m.ctrl.T.Helper()

--- a/internal/store/mock.go
+++ b/internal/store/mock.go
@@ -69,20 +69,6 @@ func (mr *MockRepositoryMockRecorder) CreateMultiple(ctx, serverID interface{}, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMultiple", reflect.TypeOf((*MockRepository)(nil).CreateMultiple), varargs...)
 }
 
-// Delete mocks base method.
-func (m *MockRepository) Delete(ctx context.Context, serverID uuid.UUID, conditionKind condition.Kind) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, serverID, conditionKind)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockRepositoryMockRecorder) Delete(ctx, serverID, conditionKind interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRepository)(nil).Delete), ctx, serverID, conditionKind)
-}
-
 // Get mocks base method.
 func (m *MockRepository) Get(ctx context.Context, serverID uuid.UUID, conditionKind condition.Kind) (*condition.Condition, error) {
 	m.ctrl.T.Helper()

--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -318,6 +318,14 @@ func (n *natsStore) Update(ctx context.Context, serverID uuid.UUID, updated *rct
 		return errors.Wrap(ErrRepository, "condition id mismatch")
 	}
 
+	// XXX: Having multiple conditions composed together into a single unit of work makes
+	// managing the state of that unit a little more complicated than merely following the
+	// state of the consitutent conditions. The state of the unit starts as Pending,
+	// transitions to Active when the first update to Active for any condition arrives,
+	// transitions to Failed if any condition fails, and transitions to Success when the
+	// last condition is completed successfully. So to know whether a given success should
+	// be applied to the unit, we need to know if this condition is the last.
+
 	var lastCondition bool
 	lastConditionPosition := len(cr.Conditions) - 1
 	for idx, cond := range cr.Conditions {

--- a/pkg/api/v1/events/handlers.go
+++ b/pkg/api/v1/events/handlers.go
@@ -101,7 +101,7 @@ func (h *Handler) UpdateCondition(ctx context.Context, updEvt *v1types.Condition
 	}
 
 	// merge update with existing
-	revisedCondition, err := updEvt.MergeExisting(existing, false)
+	revisedCondition, err := updEvt.MergeExisting(existing)
 	if err != nil {
 		h.logger.WithError(err).WithFields(logrus.Fields{
 			"serverID":         updEvt.ConditionUpdate.ServerID,

--- a/pkg/api/v1/events/handlers.go
+++ b/pkg/api/v1/events/handlers.go
@@ -94,14 +94,6 @@ func (h *Handler) UpdateCondition(ctx context.Context, updEvt *v1types.Condition
 		return errors.Wrap(errRetryThis, err.Error())
 	}
 
-	if existing == nil {
-		h.logger.WithFields(logrus.Fields{
-			"serverID":      updEvt.ConditionUpdate.ServerID,
-			"conditionKind": updEvt.Kind,
-		}).Error("no existing condition found for update")
-		return errors.New("nil existing condition with no error on retrieve")
-	}
-
 	// nothing to update
 	if existing.State == updEvt.ConditionUpdate.State &&
 		bytes.Equal(existing.Status, updEvt.ConditionUpdate.Status) {
@@ -115,7 +107,6 @@ func (h *Handler) UpdateCondition(ctx context.Context, updEvt *v1types.Condition
 			"serverID":         updEvt.ConditionUpdate.ServerID,
 			"conditionKind":    updEvt.Kind,
 			"incoming_state":   updEvt.State,
-			"incoming_version": updEvt.ResourceVersion,
 			"existing_state":   existing.State,
 			"existing_version": existing.ResourceVersion,
 		}).Warn("condition merge failed")

--- a/pkg/api/v1/events/handlers_test.go
+++ b/pkg/api/v1/events/handlers_test.go
@@ -14,10 +14,220 @@ import (
 	"github.com/volatiletech/null/v8"
 
 	"github.com/metal-toolbox/conditionorc/internal/store"
+	v1types "github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
 
+	rctypes "github.com/metal-toolbox/rivets/condition"
 	serversvc "go.hollow.sh/serverservice/pkg/api/v1"
 	mock_events "go.hollow.sh/toolbox/events/mock"
 )
+
+func TestUpdateEvent(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid update", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		stream := mock_events.NewMockStream(ctrl)
+		repo := store.NewMockRepository(ctrl)
+
+		handler := NewHandler(repo, stream, logrus.New())
+
+		arg := v1types.ConditionUpdateEvent{}
+		err := handler.UpdateCondition(context.TODO(), &arg)
+		require.ErrorIs(t, err, v1types.ErrUpdatePayload)
+	})
+	t.Run("read for existing condition fails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		stream := mock_events.NewMockStream(ctrl)
+		repo := store.NewMockRepository(ctrl)
+
+		handler := NewHandler(repo, stream, logrus.New())
+		serverID := uuid.New()
+		testKind := rctypes.Kind("test")
+		conditionID := uuid.New()
+		status := []byte(`{ "msg":"it's happening!" }`)
+		gomock.InOrder(
+			repo.EXPECT().Get(
+				gomock.Any(),
+				serverID,
+				testKind,
+			).Times(1).Return(nil, errors.New("not today")),
+		)
+
+		arg := v1types.ConditionUpdateEvent{
+			Kind: testKind,
+			ConditionUpdate: v1types.ConditionUpdate{
+				ConditionID: conditionID,
+				ServerID:    serverID,
+				State:       rctypes.Active,
+				Status:      status,
+			},
+		}
+		err := handler.UpdateCondition(context.TODO(), &arg)
+		require.ErrorIs(t, err, errRetryThis)
+	})
+	t.Run("no existing condition", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		stream := mock_events.NewMockStream(ctrl)
+		repo := store.NewMockRepository(ctrl)
+
+		handler := NewHandler(repo, stream, logrus.New())
+		serverID := uuid.New()
+		testKind := rctypes.Kind("test")
+		conditionID := uuid.New()
+		status := []byte(`{ "msg":"it's happening!" }`)
+		gomock.InOrder(
+			repo.EXPECT().Get(
+				gomock.Any(),
+				serverID,
+				testKind,
+			).Times(1).Return(nil, store.ErrConditionNotFound),
+		)
+
+		arg := v1types.ConditionUpdateEvent{
+			Kind: testKind,
+			ConditionUpdate: v1types.ConditionUpdate{
+				ConditionID: conditionID,
+				ServerID:    serverID,
+				State:       rctypes.Active,
+				Status:      status,
+			},
+		}
+		err := handler.UpdateCondition(context.TODO(), &arg)
+		require.ErrorIs(t, err, store.ErrConditionNotFound)
+	})
+	t.Run("no-op update", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		stream := mock_events.NewMockStream(ctrl)
+		repo := store.NewMockRepository(ctrl)
+
+		handler := NewHandler(repo, stream, logrus.New())
+		serverID := uuid.New()
+		testKind := rctypes.Kind("test")
+		conditionID := uuid.New()
+		status := []byte(`{ "msg":"it's happening!" }`)
+		gomock.InOrder(
+			repo.EXPECT().Get(
+				gomock.Any(),
+				serverID,
+				testKind,
+			).Times(1).Return(&rctypes.Condition{
+				ID:     conditionID,
+				Kind:   testKind,
+				State:  rctypes.Active,
+				Status: status,
+			}, nil),
+		)
+
+		arg := v1types.ConditionUpdateEvent{
+			Kind: testKind,
+			ConditionUpdate: v1types.ConditionUpdate{
+				ConditionID: conditionID,
+				ServerID:    serverID,
+				State:       rctypes.Active,
+				Status:      status,
+			},
+		}
+		err := handler.UpdateCondition(context.TODO(), &arg)
+		require.NoError(t, err)
+	})
+	t.Run("update fails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		stream := mock_events.NewMockStream(ctrl)
+		repo := store.NewMockRepository(ctrl)
+
+		handler := NewHandler(repo, stream, logrus.New())
+		serverID := uuid.New()
+		testKind := rctypes.Kind("test")
+		conditionID := uuid.New()
+
+		gomock.InOrder(
+			repo.EXPECT().Get(
+				gomock.Any(),
+				serverID,
+				testKind,
+			).Times(1).Return(&rctypes.Condition{
+				ID:     conditionID,
+				Kind:   testKind,
+				State:  rctypes.Active,
+				Status: []byte(`{ "msg":"still waiting" }`),
+			}, nil),
+			repo.EXPECT().Update(
+				gomock.Any(),
+				serverID,
+				gomock.Any(),
+			).Times(1).Return(errors.New("not happening")),
+		)
+
+		arg := v1types.ConditionUpdateEvent{
+			Kind: testKind,
+			ConditionUpdate: v1types.ConditionUpdate{
+				ConditionID: conditionID,
+				ServerID:    serverID,
+				State:       rctypes.Active,
+				Status:      []byte(`{ "msg":"it's happening!" }`),
+			},
+		}
+		err := handler.UpdateCondition(context.TODO(), &arg)
+		require.ErrorIs(t, err, errRetryThis)
+	})
+	t.Run("update succeeds", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		stream := mock_events.NewMockStream(ctrl)
+		repo := store.NewMockRepository(ctrl)
+
+		handler := NewHandler(repo, stream, logrus.New())
+		serverID := uuid.New()
+		testKind := rctypes.Kind("test")
+		conditionID := uuid.New()
+
+		gomock.InOrder(
+			repo.EXPECT().Get(
+				gomock.Any(),
+				serverID,
+				testKind,
+			).Times(1).Return(&rctypes.Condition{
+				ID:     conditionID,
+				Kind:   testKind,
+				State:  rctypes.Active,
+				Status: []byte(`{ "msg":"still waiting" }`),
+			}, nil),
+			repo.EXPECT().Update(
+				gomock.Any(),
+				serverID,
+				gomock.Any(), // we test the merge function elsewhere, don't bother here
+			).Times(1).Return(nil),
+		)
+
+		arg := v1types.ConditionUpdateEvent{
+			Kind: testKind,
+			ConditionUpdate: v1types.ConditionUpdate{
+				ConditionID: conditionID,
+				ServerID:    serverID,
+				State:       rctypes.Active,
+				Status:      []byte(`{ "msg":"it's happening!" }`),
+			},
+		}
+		err := handler.UpdateCondition(context.TODO(), &arg)
+		require.NoError(t, err)
+	})
+}
 
 func TestServerserviceEvent(t *testing.T) {
 	t.Parallel()

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -146,7 +146,7 @@ func (r *Routes) serverEnroll(c *gin.Context) (int, *v1types.ServerResponse) {
 			}).Info("bad serverID")
 
 			return http.StatusBadRequest, &v1types.ServerResponse{
-				Message: err.Error(),
+				Message: "server id: " + err.Error(),
 			}
 		}
 	} else {
@@ -166,11 +166,11 @@ func (r *Routes) serverEnroll(c *gin.Context) (int, *v1types.ServerResponse) {
 		rollbackErr := rollback()
 		if strings.Contains(err.Error(), badRequestErrMsg) {
 			return http.StatusBadRequest, &v1types.ServerResponse{
-				Message: err.Error() + fmt.Sprintf("server rollback err: %v", rollbackErr),
+				Message: "add server: " + err.Error() + fmt.Sprintf("server rollback err: %v", rollbackErr),
 			}
 		}
 		return http.StatusInternalServerError, &v1types.ServerResponse{
-			Message: err.Error() + fmt.Sprintf("server rollback err: %v", rollbackErr),
+			Message: "add server: " + err.Error() + fmt.Sprintf("server rollback err: %v", rollbackErr),
 		}
 	}
 
@@ -206,7 +206,7 @@ func (r *Routes) conditionCreate(otelCtx context.Context, newCondition *rctypes.
 		}).Info("condition create failed")
 
 		return http.StatusInternalServerError, &v1types.ServerResponse{
-			Message: err.Error(),
+			Message: "condition create: " + err.Error(),
 		}
 	}
 
@@ -228,7 +228,7 @@ func (r *Routes) conditionCreate(otelCtx context.Context, newCondition *rctypes.
 			}).Info("condition deletion failed")
 
 			return http.StatusInternalServerError, &v1types.ServerResponse{
-				Message: deleteErr.Error(),
+				Message: "condition create cleanup: " + deleteErr.Error(),
 			}
 		}
 

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.hollow.sh/toolbox/events"
 	mockevents "go.hollow.sh/toolbox/events/mock"
 )
@@ -353,7 +354,7 @@ func TestAddServerRollback(t *testing.T) {
 		mockStoreCreateErr   mockError
 		mockFleetDBClientErr mockError
 		mockStreamErr        mockError
-		mockStoreDeleteErr   mockError
+		mockStoreUpdateErr   mockError
 		request              func(t *testing.T) *http.Request
 		assertResponse       func(t *testing.T, r *httptest.ResponseRecorder)
 		expectRollback       int
@@ -457,13 +458,13 @@ func TestAddServerRollback(t *testing.T) {
 				Times(tc.mockStreamErr.calledTime)
 
 			repository.EXPECT().
-				Delete(
+				Update(
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).
-				Return(tc.mockStoreDeleteErr.err).
-				Times(tc.mockStoreDeleteErr.calledTime)
+				Return(tc.mockStoreUpdateErr.err).
+				Times(tc.mockStoreUpdateErr.calledTime)
 
 			recorder := httptest.NewRecorder()
 			server.ServeHTTP(recorder, tc.request(t))
@@ -833,9 +834,11 @@ func TestServerConditionCreate(t *testing.T) {
 
 				// condition deletion due to publish failure
 				r.EXPECT().
-					Delete(gomock.Any(), gomock.Eq(serverID), gomock.Eq(rctypes.FirmwareInstall)).
-					Times(1).
-					Return(nil)
+					Update(gomock.Any(), gomock.Eq(serverID), gomock.Any()).
+					Times(1).DoAndReturn(func(_ context.Context, _ uuid.UUID, c *rctypes.Condition) error {
+					require.Equal(t, rctypes.Failed, c.State)
+					return nil
+				})
 			},
 
 			func(m *fleetdb.MockFleetDB) {

--- a/pkg/api/v1/routes/routes.go
+++ b/pkg/api/v1/routes/routes.go
@@ -143,6 +143,10 @@ func (r *Routes) Routes(g *gin.RouterGroup) {
 
 	servers := g.Group("/servers/:uuid")
 	{
+		// Combined API for firmwareInstall
+		servers.POST("/firmwareInstall", r.composeAuthHandler(createScopes("condition")),
+			wrapAPICall(r.firmwareInstall))
+
 		// /servers/:uuid/condition/:conditionKind
 		serverConditionBySlug := servers.Group("/condition")
 

--- a/pkg/api/v1/types/types.go
+++ b/pkg/api/v1/types/types.go
@@ -56,6 +56,7 @@ func (c *ConditionCreate) NewCondition(kind rctypes.Kind) *rctypes.Condition {
 		Exclusive:  c.Exclusive,
 		Parameters: c.Parameters,
 		Fault:      c.Fault,
+		CreatedAt:  time.Now(),
 	}
 }
 

--- a/pkg/api/v1/types/types_test.go
+++ b/pkg/api/v1/types/types_test.go
@@ -19,8 +19,6 @@ func TestValidate(t *testing.T) {
 	update.State = rctypes.Failed
 	require.Error(t, update.Validate(), "ConditionID, ServerID, State")
 	update.Status = []byte(`{"you":"lose"}`)
-	require.Error(t, update.Validate(), "ConditionID, ServerID, State, Status")
-	update.ResourceVersion = int64(5)
 	require.NoError(t, update.Validate(), "should be good")
 }
 
@@ -40,34 +38,25 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 			errBadUpdateTarget,
 		},
 		{
-			"resource version mismatch returns error",
-			&ConditionUpdate{ResourceVersion: 0},
-			&rctypes.Condition{ResourceVersion: 1},
-			nil,
-			errResourceVersionMismatch,
-		},
-		{
 			"transition state invalid error",
-			&ConditionUpdate{ResourceVersion: 1, State: rctypes.Active},
-			&rctypes.Condition{ResourceVersion: 1, State: rctypes.Failed},
+			&ConditionUpdate{State: rctypes.Active},
+			&rctypes.Condition{State: rctypes.Failed},
 			nil,
 			errInvalidStateTransition,
 		},
 		{
 			"condition ID mismatch error",
 			&ConditionUpdate{
-				ConditionID:     uuid.New(),
-				ResourceVersion: 1,
-				State:           rctypes.Active,
-				Status:          []byte("{'foo': 'bar'}"),
+				ConditionID: uuid.New(),
+				State:       rctypes.Active,
+				Status:      []byte("{'foo': 'bar'}"),
 			},
 			&rctypes.Condition{
-				ID:              uuid.New(),
-				Kind:            rctypes.FirmwareInstall,
-				Parameters:      nil,
-				ResourceVersion: 1,
-				State:           rctypes.Pending,
-				Status:          []byte("{'woo': 'alala'}"),
+				ID:         uuid.New(),
+				Kind:       rctypes.FirmwareInstall,
+				Parameters: nil,
+				State:      rctypes.Pending,
+				Status:     []byte("{'woo': 'alala'}"),
 			},
 			nil,
 			errBadUpdateTarget,
@@ -75,27 +64,24 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 		{
 			"existing merged with update",
 			&ConditionUpdate{
-				ConditionID:     uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
-				ServerID:        uuid.MustParse("f2cd1ef8-c759-4049-905e-f6fdf61719a9"),
-				ResourceVersion: 1,
-				State:           rctypes.Active,
-				Status:          []byte("{'foo': 'bar'}"),
+				ConditionID: uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
+				ServerID:    uuid.MustParse("f2cd1ef8-c759-4049-905e-f6fdf61719a9"),
+				State:       rctypes.Active,
+				Status:      []byte("{'foo': 'bar'}"),
 			},
 			&rctypes.Condition{
-				Kind:            rctypes.FirmwareInstall,
-				ID:              uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
-				Parameters:      nil,
-				ResourceVersion: 1,
-				State:           rctypes.Pending,
-				Status:          []byte("{'woo': 'alala'}"),
+				Kind:       rctypes.FirmwareInstall,
+				ID:         uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
+				Parameters: nil,
+				State:      rctypes.Pending,
+				Status:     []byte("{'woo': 'alala'}"),
 			},
 			&rctypes.Condition{
-				ID:              uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
-				Kind:            rctypes.FirmwareInstall,
-				Parameters:      nil,
-				ResourceVersion: 1,
-				State:           rctypes.Active,
-				Status:          []byte("{'foo': 'bar'}"),
+				ID:         uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
+				Kind:       rctypes.FirmwareInstall,
+				Parameters: nil,
+				State:      rctypes.Active,
+				Status:     []byte("{'foo': 'bar'}"),
 			},
 			nil,
 		},

--- a/pkg/api/v1/types/types_test.go
+++ b/pkg/api/v1/types/types_test.go
@@ -88,7 +88,7 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.update.MergeExisting(tt.existing, true)
+			got, err := tt.update.MergeExisting(tt.existing)
 			if tt.wantErr != nil {
 				require.Error(t, err, "no error when one is expected")
 				require.Equal(t, tt.wantErr, err, "error does not match expectation")

--- a/sample/firmwareInstall.md
+++ b/sample/firmwareInstall.md
@@ -1,70 +1,48 @@
  #### Queue a firmware-set install
 
 request
- ```bash
-   curl -Lv https://conditionapi/api/v1/servers/a5e051cd-dcb1-4de2-b8fa-2571b7381653/condition/firmwareInstall
-       -X POST
-       -d '{
- 		      "exclusive": true,
- 		      "parameters": {
- 			     "asset_id": "a5e051cd-dcb1-4de2-b8fa-2571b7381653",
- 			    "firmware_set_id": "7b4cca35-eb46-49fc-8c30-a4e5ec689303"
- 		      }
- 	       }'
+```bash
+   curl -i --json @fwInstall.json https://<conditionAPI URL>/api/v1/servers/<server_UUID>/firmwareInstall
+```
+
+fwInstall.json
+```json
+   {
+       "asset_id": "<server UUID>",
+       "firmware_set_id": "<firmware set UUID>",
+       "reset_bmc_before_install": true,
+       "dry_run": true
+   }
 ```
 
 response
 ```json
- {
- 	"message": "condition set",
- 	"records": {
- 		"serverID": "ede81024-f62a-4288-8730-3fab8cceab78",
- 		"conditions": [
- 			{
- 				"version": "1",
- 				"id": "b9e5ac5a-e8a3-4506-a83e-576562fa5701",
- 				"kind": "firmwareInstall",
- 				"parameters": {
- 					"asset_id": "ede81024-f62a-4288-8730-3fab8cceab78",
- 					"firmware_set_id": "7b4cca35-eb46-49fc-8c30-a4e5ec689303"
- 				},
- 				"state": "pending",
- 				"exclusive": true,
- 				"resourceVersion": 1695734722314951200,
- 				"updatedAt": "0001-01-01T00:00:00Z",
- 				"createdAt": "0001-01-01T00:00:00Z"
- 			}
- 		]
- 	}
- }
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Mon, 20 Nov 2023 19:18:01 GMT
+Content-Length: 40
+
+{"message":"firmware install scheduled"}
 ```
 
 ### Query firmware-set install status
 
 ```bash
-curl -Lv https://conditionapi/api/v1/servers/ede81024-f62a-4288-8730-3fab8cceab78/condition/firmwareInstall
+./mctl --config config.yaml install status -s <server UUID>
 {
-  "records": {
-    "serverID": "ede81024-f62a-4288-8730-3fab8cceab78",
-    "conditions": [
-      {
-        "version": "1",
-        "id": "c3e3e7cc-f3be-4276-9746-ece745f485bc",
-        "kind": "firmwareInstall",
-        "parameters": {
-          "asset_id": "ede81024-f62a-4288-8730-3fab8cceab78",
-          "firmware_set_id": "7b4cca35-eb46-49fc-8c30-a4e5ec689303",
-        },
-        "state": "succeeded",
-        "status": {
-          "msg": "component: bios, completed firmware install, version: 2.12.4"
-        },
-        "exclusive": true,
-        "resourceVersion": 1695813453549651700,
-        "updatedAt": "2023-09-27T10:46:40.878708Z",
-        "createdAt": "2023-09-27T10:46:40.878708Z"
-      }
-    ]
-  }
+  "id": "<internal condition UUID>",
+  "kind": "firmwareInstall",
+  "state": "succeeded",
+  "parameters": {
+    "asset_id": "<server UUID>",
+    "reset_bmc_before_install": true,
+    "dry_run": true,
+    "firmware_set_id": "<firmware set UUID>"
+  },
+  "status": {
+    "msg": "component: bios, completed firmware install, version: 2.8.5"
+  },
+  "updated_at": "2023-11-20T19:41:26.641921011Z",
+  "created_at": "2023-11-20T19:39:36.206522668Z"
 }
 ```


### PR DESCRIPTION
#### What does this PR do
This PR builds on the concept of `conditionRecord` within ConditionAPI and Condition-Orchestrator. Multiple conditions can be queued for a server simultaneously and they will be executed as a single, atomic unit of work. All conditions must succeed for this task to be successful. Task execution will abort on the first failure. The presence of an active, incomplete conditionRecord will block queuing any other work for that server.
