### PR TITLE
return conditions to caller

### DIFF
--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -360,6 +360,14 @@ func (r *Routes) firmwareInstall(c *gin.Context) (int, *v1types.ServerResponse) 
 
 	return http.StatusOK, &v1types.ServerResponse{
 		Message: "firmware install scheduled",
+		Records: &v1types.ConditionsResponse{
+			ServerID: serverID,
+			State:    rctypes.Pending,
+			Conditions: []*rctypes.Condition{
+				fwCondition,
+				invCondition,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
#### What does this PR do
This restores the behavior of returning the conditions created from a firmwareInstall to the caller.