### PR TITLE
Update server enroll docs and params with bmc- prefix

### DIFF
--- a/pkg/api/v1/client/client_test.go
+++ b/pkg/api/v1/client/client_test.go
@@ -612,7 +612,12 @@ func TestServerEnrollEmptyUUID(t *testing.T) {
 	defer finish()
 
 	var generatedServerID uuid.UUID
-	validParams := `{"facility":"mock-facility-code","ip":"mock-ip","user":"mock-user","pwd":"mock-pwd","some param":"1","collect_firmware_status":true,"inventory_method":"outofband"}`
+	validParams := types.AddServerParams{
+		Facility: "mock-facility-code",
+		IP:       "mock-ip",
+		Username: "mock-user",
+		Password: "mock-pwd",
+	}
 	expectedInventoryParams := func(id string) string {
 		return fmt.Sprintf(`{"collect_bios_cfg":true,"collect_firmware_status":true,"inventory_method":"outofband","asset_id":"%v"}`, id)
 	}
@@ -655,7 +660,7 @@ func TestServerEnrollEmptyUUID(t *testing.T) {
 	tester.stream.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		Return(nil)
 
-	got, err := tester.client.ServerEnroll(context.TODO(), "", v1types.ConditionCreate{Parameters: []byte(validParams)})
+	got, err := tester.client.ServerEnroll(context.TODO(), "", v1types.ConditionCreate{Parameters: validParams.MustJSON()})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/metal-toolbox/conditionorc/internal/model"
 	"github.com/metal-toolbox/conditionorc/internal/store"
 	storeTest "github.com/metal-toolbox/conditionorc/internal/store/test"
+	"github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
 	v1types "github.com/metal-toolbox/conditionorc/pkg/api/v1/types"
 	rctypes "github.com/metal-toolbox/rivets/condition"
 	"github.com/pkg/errors"
@@ -118,7 +119,12 @@ func TestAddServer(t *testing.T) {
 	mockIP := "mock-ip"
 	mockUser := "mock-user"
 	mockPwd := "mock-pwd"
-	validParams := fmt.Sprintf(`{"facility":"%v","ip":"%v","user":"%v","pwd":"%v","some param":"1","asset_id":"%v","collect_firmware_status":true,"inventory_method":"outofband"}`, mockFacilityCode, mockIP, mockUser, mockPwd, mockServerID)
+	validParams := types.AddServerParams{
+		Facility: "mock-facility-code",
+		IP:       "mock-ip",
+		Username: "mock-user",
+		Password: "mock-pwd",
+	}
 	// collect_bios_cfg is default to false since we don't set it in validParams.
 	expectedInventoryParams := func(id string) string {
 		return fmt.Sprintf(`{"collect_bios_cfg":true,"collect_firmware_status":true,"inventory_method":"outofband","asset_id":"%v"}`, id)
@@ -126,7 +132,6 @@ func TestAddServer(t *testing.T) {
 	nopRollback := func() error {
 		return nil
 	}
-	validParamsNoAssetID := fmt.Sprintf(`{"facility":"%v","ip":"%v","user":"%v","pwd":"%v","some param":"1","collect_firmware_status":true,"inventory_method":"outofband"}`, mockFacilityCode, mockIP, mockUser, mockPwd)
 	var generatedServerID uuid.UUID
 	testcases := []struct {
 		name              string
@@ -181,7 +186,7 @@ func TestAddServer(t *testing.T) {
 					Times(1)
 			},
 			func(t *testing.T) *http.Request {
-				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: []byte(validParams)})
+				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: validParams.MustJSON()})
 				if err != nil {
 					t.Error()
 				}
@@ -237,8 +242,12 @@ func TestAddServer(t *testing.T) {
 			},
 			nil,
 			func(t *testing.T) *http.Request {
-				noUserParams := fmt.Sprintf(`{"facility":"%v","ip":"%v","pwd":"%v","some param":"1"}`, mockFacilityCode, mockIP, mockPwd)
-				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: []byte(noUserParams)})
+				noUserParams := types.AddServerParams{
+					Facility: "mock-facility-code",
+					IP:       "mock-ip",
+					Password: "mock-pwd",
+				}
+				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: noUserParams.MustJSON()})
 				if err != nil {
 					t.Error()
 				}
@@ -275,8 +284,12 @@ func TestAddServer(t *testing.T) {
 			},
 			nil,
 			func(t *testing.T) *http.Request {
-				noPwdParams := fmt.Sprintf(`{"facility":"%v","ip":"%v","user":"%v","some param":"1"}`, mockFacilityCode, mockIP, mockUser)
-				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: []byte(noPwdParams)})
+				noPwdParams := types.AddServerParams{
+					Facility: "mock-facility-code",
+					IP:       "mock-ip",
+					Username: "mock-user",
+				}
+				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: noPwdParams.MustJSON()})
 				if err != nil {
 					t.Error()
 				}
@@ -343,7 +356,7 @@ func TestAddServer(t *testing.T) {
 					Times(1)
 			},
 			func(t *testing.T) *http.Request {
-				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: []byte(validParamsNoAssetID)})
+				payload, err := json.Marshal(&v1types.ConditionCreate{Parameters: validParams.MustJSON()})
 				if err != nil {
 					t.Error()
 				}

--- a/pkg/api/v1/types/types.go
+++ b/pkg/api/v1/types/types.go
@@ -41,9 +41,9 @@ type ConditionCreate struct {
 // AddServerParams is the request payload to add a server to fleetdb.
 type AddServerParams struct {
 	Facility string `json:"facility"`
-	IP       string `json:"ip"`
-	Username string `json:"user"`
-	Password string `json:"pwd"`
+	IP       string `json:"bmc-ip"`
+	Username string `json:"bmc-user"`
+	Password string `json:"bmc-pwd"`
 }
 
 func (asp *AddServerParams) MustJSON() []byte {

--- a/sample/serverenroll.md
+++ b/sample/serverenroll.md
@@ -4,7 +4,7 @@ request
 ```bash
    curl -i -X POST --header 'Content-Type: application/json' \
 'localhost:9001/api/v1/serverEnroll/<server UUID>'  \
-    -d '{"parameters":{"facility":"sandbox","ip":"fakeip","user":"root","pwd":"fakepwd","collect_firmware_status":true,"inventory_method":"outofband"}}'
+    -d '{"parameters":{"facility":"sandbox","bmc-ip":"fakeip","bmc-user":"root","bmc-pwd":"fakepwd"}}'
 ```
 
 response


### PR DESCRIPTION
- Remove `"collect_firmware_status":true, inventory_method":"outofband"`
  - They are not respected since they are hard coded [here](https://github.com/metal-toolbox/conditionorc/blob/main/pkg/api/v1/routes/handlers.go#L249-L254)
 - Add `bmc-` for `user`, `pwd` and `ip` to server enroll params.