### PR TITLE
[FS-1253] make 'no active condition' handling uniform

### DIFF
--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -115,16 +115,12 @@ func (n *natsStore) GetActiveCondition(ctx context.Context, serverID uuid.UUID) 
 	})
 
 	cr, err := n.getCurrentConditionRecord(otelCtx, serverID)
-	if errors.Is(err, ErrConditionNotFound) {
-		return nil, nil
-	}
-
 	if err != nil {
 		return nil, err
 	}
 
 	if rctypes.StateIsComplete(cr.State) {
-		return nil, nil
+		return nil, ErrConditionNotFound
 	}
 
 	var active *rctypes.Condition

--- a/internal/store/nats_test.go
+++ b/internal/store/nats_test.go
@@ -108,7 +108,7 @@ func TestCreateReadUpdate(t *testing.T) {
 	require.ErrorIs(t, err, ErrConditionNotFound)
 
 	active, err := store.GetActiveCondition(context.TODO(), serverID)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrConditionNotFound)
 	require.Nil(t, active)
 
 	// add a condition
@@ -116,6 +116,7 @@ func TestCreateReadUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	active, err = store.GetActiveCondition(context.TODO(), serverID)
+	require.NoError(t, err)
 	require.NotNil(t, active)
 
 	// get the new condition
@@ -138,7 +139,7 @@ func TestCreateReadUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	active, err = store.GetActiveCondition(context.TODO(), serverID)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrConditionNotFound)
 	require.Nil(t, active)
 
 	cr, err = store.Get(context.TODO(), serverID)
@@ -220,7 +221,7 @@ func TestMultipleConditionUpdate(t *testing.T) {
 		require.NoError(t, err, "second update - succeeded")
 
 		active, err = store.GetActiveCondition(context.TODO(), serverID)
-		require.NoError(t, err, "GetActiveCondition IV")
+		require.ErrorIs(t, err, ErrConditionNotFound, "GetActiveCondition IV")
 		require.Nil(t, active)
 
 		cr, err := store.Get(context.TODO(), serverID)
@@ -262,7 +263,7 @@ func TestMultipleConditionUpdate(t *testing.T) {
 		require.NoError(t, err, "first update - failed")
 
 		active, err = store.GetActiveCondition(context.TODO(), serverID)
-		require.NoError(t, err, "GetActiveCondition III")
+		require.ErrorIs(t, err, ErrConditionNotFound, "GetActiveCondition III")
 		require.Nil(t, active)
 
 		cr, err := store.Get(context.TODO(), serverID)

--- a/pkg/api/v1/events/handlers.go
+++ b/pkg/api/v1/events/handlers.go
@@ -86,8 +86,9 @@ func (h *Handler) UpdateCondition(ctx context.Context, updEvt *v1types.Condition
 	if err != nil {
 		if errors.Is(err, store.ErrConditionNotFound) {
 			h.logger.WithFields(logrus.Fields{
-				"serverID":      updEvt.ConditionUpdate.ServerID,
-				"conditionKind": updEvt.Kind,
+				"server_id":      updEvt.ConditionUpdate.ServerID,
+				"condition_id":   updEvt.ConditionUpdate.ConditionID,
+				"condition_kind": updEvt.Kind,
 			}).Error("no existing condition found for update")
 			return err
 		}

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -105,7 +105,7 @@ func (r *Routes) serverConditionCreate(c *gin.Context) (int, *v1types.ServerResp
 	}
 
 	active, err := r.repository.GetActiveCondition(otelCtx, serverID)
-	if err != nil {
+	if err != nil && !errors.Is(err, store.ErrConditionNotFound) {
 		return http.StatusServiceUnavailable, &v1types.ServerResponse{
 			Message: "error checking server state: " + err.Error(),
 		}
@@ -154,7 +154,7 @@ func (r *Routes) serverDelete(c *gin.Context) (int, *v1types.ServerResponse) {
 	}
 
 	active, err := r.repository.GetActiveCondition(otelCtx, serverID)
-	if err != nil {
+	if err != nil && !errors.Is(err, store.ErrConditionNotFound) {
 		return http.StatusServiceUnavailable, &v1types.ServerResponse{
 			Message: "error checking server state: " + err.Error(),
 		}


### PR DESCRIPTION
#### What does this PR do

We observed a panic in the condition update routine under load where a delayed or replayed update resulted in a nil, no-error return from the `GetActiveCondition` call. Further investigation found the semantics of this call were inconsistent, with some code checking for `nil` explicitly and some assuming that `ErrConditionNotFound` would be returned.

Here we change this to be more-consistent, where we explicitly return `ErrConditionNotFound` when such is appropriate (that is, either there is no condition to find, *or* that condition is in a completed state).