### PR TITLE
update builder golang image to 1.22 on Alpine 3.19

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine3.18 AS build
+FROM golang:1.22-alpine3.19 AS build
 
 WORKDIR /go/src/github.com/metal-toolbox/conditionorc
 COPY go.mod go.sum ./


### PR DESCRIPTION
#### What does this PR do

