### PR TITLE
Active condition records reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,6 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.3
-	github.com/volatiletech/null/v8 v8.1.2
-	go.hollow.sh/serverservice v0.16.2
 	go.hollow.sh/toolbox v0.6.3
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0
 	go.opentelemetry.io/otel v1.24.0
@@ -118,6 +116,7 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/volatiletech/inflect v0.0.1 // indirect
 	github.com/volatiletech/null v8.0.0+incompatible // indirect
+	github.com/volatiletech/null/v8 v8.1.2 // indirect
 	github.com/volatiletech/randomize v0.0.1 // indirect
 	github.com/volatiletech/sqlboiler v3.7.1+incompatible // indirect
 	github.com/volatiletech/sqlboiler/v4 v4.16.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/metal-toolbox/fleetdb v0.16.9
-	github.com/metal-toolbox/rivets v1.0.5-0.20240502123110-b4bca7161ddb
+	github.com/metal-toolbox/rivets v1.0.5-0.20240507101451-ee305d6c8428
 	github.com/nats-io/nats-server/v2 v2.10.11
 	github.com/nats-io/nats.go v1.33.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,8 @@ github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal-toolbox/fleetdb v0.16.9 h1:cU8izN7tTi4dnGisP43MgK2ddtbrJJ4zLLwIS3wRABw=
 github.com/metal-toolbox/fleetdb v0.16.9/go.mod h1:L2FavoKCdpewj759/MepRmbInSE0JpuSOMnXJho9u3o=
-github.com/metal-toolbox/rivets v1.0.5-0.20240502123110-b4bca7161ddb h1:uqFbRBrOgiQQhsyfnaKJx58fC0fJQJKMGIbjwmQ9j5c=
-github.com/metal-toolbox/rivets v1.0.5-0.20240502123110-b4bca7161ddb/go.mod h1:EMQJRT1mjIyFRXxvKNaBlz7Z4Sp88rTaGO8W18olN2I=
+github.com/metal-toolbox/rivets v1.0.5-0.20240507101451-ee305d6c8428 h1:6Ia4qGHNmbgmoUlOB5ZHfVU+XJgaoJv4y/qnfT+DEso=
+github.com/metal-toolbox/rivets v1.0.5-0.20240507101451-ee305d6c8428/go.mod h1:EMQJRT1mjIyFRXxvKNaBlz7Z4Sp88rTaGO8W18olN2I=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/go.sum
+++ b/go.sum
@@ -537,10 +537,6 @@ github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal-toolbox/fleetdb v0.16.9 h1:cU8izN7tTi4dnGisP43MgK2ddtbrJJ4zLLwIS3wRABw=
 github.com/metal-toolbox/fleetdb v0.16.9/go.mod h1:L2FavoKCdpewj759/MepRmbInSE0JpuSOMnXJho9u3o=
-github.com/metal-toolbox/rivets v1.0.5-0.20240423145705-d3616d0ebde4 h1:NVZ3QsNkoI91eRfONLLOSq05dsjte0dphULPyONie3U=
-github.com/metal-toolbox/rivets v1.0.5-0.20240423145705-d3616d0ebde4/go.mod h1:EMQJRT1mjIyFRXxvKNaBlz7Z4Sp88rTaGO8W18olN2I=
-github.com/metal-toolbox/rivets v1.0.5-0.20240426130835-f0a8cb5ba950 h1:Ygz87P8ARXa0Cu1sBJRRBXDWIC+kX0ABW5PwkuwTQM8=
-github.com/metal-toolbox/rivets v1.0.5-0.20240426130835-f0a8cb5ba950/go.mod h1:EMQJRT1mjIyFRXxvKNaBlz7Z4Sp88rTaGO8W18olN2I=
 github.com/metal-toolbox/rivets v1.0.5-0.20240502123110-b4bca7161ddb h1:uqFbRBrOgiQQhsyfnaKJx58fC0fJQJKMGIbjwmQ9j5c=
 github.com/metal-toolbox/rivets v1.0.5-0.20240502123110-b4bca7161ddb/go.mod h1:EMQJRT1mjIyFRXxvKNaBlz7Z4Sp88rTaGO8W18olN2I=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
@@ -741,8 +737,6 @@ go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dY
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.4/go.mod h1:Ud+VUwIi9/uQHOMA+4ekToJ12lTxlv0zB/+DHwTGEbU=
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
-go.hollow.sh/serverservice v0.16.2 h1:0wt0XJC/rm4OdovB6g8Fsx7BT2X71pG0keJiiLZaY+w=
-go.hollow.sh/serverservice v0.16.2/go.mod h1:Zr99vSFO++ZlDjEf9rtPWi3TiMgMswJCW3D6LIFmMDM=
 go.hollow.sh/toolbox v0.6.3 h1:IJOjiGdiwWwXJ2QfOkJuSucSIqrdXJbUBFst3u6T6z4=
 go.hollow.sh/toolbox v0.6.3/go.mod h1:nl+5RDDyYY/+wukOUzHHX2mOyWKRjlTOXUcGxny+tns=
 go.infratographer.com/x v0.3.9 h1:fsfF/w5zHgiNAHvYmvsWlICNha2X53WNLVSKOkyPnWo=

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -145,3 +145,13 @@ func RegisterSpanEvent(span trace.Span, serverID, conditionID, conditionKind, ev
 		attribute.String("conditionKind", conditionKind),
 	))
 }
+
+func RegisterSpanEventKVParseError(span trace.Span, key, serverID, conditionID, conditionKind, err string) {
+	span.AddEvent("Status KV entry parse error", trace.WithAttributes(
+		attribute.String("key", key),
+		attribute.String("serverID", serverID),
+		attribute.String("conditionID", conditionID),
+		attribute.String("conditionKind", conditionKind),
+		attribute.String("err", err),
+	))
+}

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -293,7 +293,20 @@ func failedUpdateEventFromCondition(cond *rctypes.Condition) *v1types.ConditionU
 	}
 }
 
-func filterPendingRecords(records []*store.ConditionRecord) (map[rctypes.Kind]bool, []*store.ConditionRecord) {
+func conditionFromUpdateEvent(evt *v1types.ConditionUpdateEvent) *rctypes.Condition {
+	return &rctypes.Condition{
+		Version:   rctypes.ConditionStructVersion,
+		ID:        evt.ConditionID,
+		Target:    evt.ServerID,
+		Kind:      evt.Kind,
+		State:     evt.State,
+		Status:    evt.Status,
+		CreatedAt: evt.CreatedAt,
+		UpdatedAt: evt.UpdatedAt,
+	}
+}
+
+func filterIncompleteRecords(records []*store.ConditionRecord) (map[rctypes.Kind]bool, []*store.ConditionRecord) {
 	foundKinds := map[rctypes.Kind]bool{}
 	foundRecords := []*store.ConditionRecord{}
 
@@ -311,24 +324,45 @@ func filterPendingRecords(records []*store.ConditionRecord) (map[rctypes.Kind]bo
 	return foundKinds, foundRecords
 }
 
-// Conditions are candidates for reconciling when it matches this criteria,
-//
-// - The State for a ConditionRecord in the active-condition KV is non-final
-// - The status KV entry does not exist for the condition listed in active-condition condition
-// - The first incomplete Condition has exceeded the stale threshold
-func filterConditionsToReconcile(records []*store.ConditionRecord, serverIDs map[string]struct{}) []*v1types.ConditionUpdateEvent {
-	forUpdate := []*v1types.ConditionUpdateEvent{}
+// Method returns a slice of Conditions along with a slice of ConditionUpdateEvents which
+// are to be applied to the active-condition KV.
+func filterToReconcile(records []*store.ConditionRecord, updateEvts map[string]*v1types.ConditionUpdateEvent) ([]*rctypes.Condition, []*v1types.ConditionUpdateEvent) {
+	currentCRs := map[string]struct{}{}
 
+	// missing conditions in active-conditions KV to be created
+	creates := []*rctypes.Condition{}
+
+	// in-complete status KV updates to be applied
+	updates := []*v1types.ConditionUpdateEvent{}
+
+	stale := func(createdAt, updatedAt time.Time) bool {
+		return time.Since(createdAt) >= rctypes.StaleThreshold &&
+			time.Since(updatedAt) >= rcontroller.StatusStaleThreshold
+	}
+
+	// updates
+	// - The status KV entry does not exist for the condition listed in active-condition condition
+	// - The first incomplete Condition has exceeded the stale threshold
 	for _, cr := range records {
 		firstCond := cr.Conditions[0]
-		_, exists := serverIDs[firstCond.Target.String()]
+		currentCRs[firstCond.Target.String()] = struct{}{}
 
-		if !exists && time.Since(firstCond.CreatedAt) > rctypes.StaleThreshold {
-			forUpdate = append(forUpdate, failedUpdateEventFromCondition(firstCond))
+		_, exists := updateEvts[firstCond.Target.String()]
+		if !exists && stale(firstCond.CreatedAt, firstCond.UpdatedAt) {
+			updates = append(updates, failedUpdateEventFromCondition(firstCond))
 		}
 	}
 
-	return forUpdate
+	//  creates
+	// - The non-final Condition Status entry has no corresponding Active Condition Record.
+	for serverID, updateEvt := range updateEvts {
+		_, exists := currentCRs[serverID]
+		if !exists {
+			creates = append(creates, conditionFromUpdateEvent(updateEvt))
+		}
+	}
+
+	return creates, updates
 }
 
 func (o *Orchestrator) activeConditionsToReconcile(ctx context.Context) []*v1types.ConditionUpdateEvent {

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -380,6 +380,8 @@ func (o *Orchestrator) activeConditionsToReconcile(ctx context.Context) ([]*rcty
 	records, err := o.repository.List(ctx)
 	if err != nil {
 		o.logger.WithError(err).Error("condition record lookup error")
+
+		return nil, nil
 	}
 
 	// filter condition Kinds and records to be reconciled

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -163,22 +163,8 @@ func (o *Orchestrator) startConditionWatchers(ctx context.Context,
 						o.logger.WithError(err).WithField("rctypes.kind", string(kind)).
 							Warn("error transforming status data")
 
-						metrics.NatsKVUpdateEvent.With(
-							prometheus.Labels{
-								"conditionKind": string(evt.Kind),
-								"valid":         "false",
-							},
-						).Inc()
-
 						continue
 					}
-
-					metrics.NatsKVUpdateEvent.With(
-						prometheus.Labels{
-							"conditionKind": string(evt.Kind),
-							"valid":         "true",
-						},
-					).Inc()
 
 					evtChan <- evt
 				}
@@ -214,10 +200,35 @@ func parseStatusKVKey(key string) (*statusKey, error) {
 // parseEventUpdateFromKV converts the stored rivets.StatusValue (the value from the KV) to a
 // ConditionOrchestrator-native type that ConditionOrc can more-easily use for its
 // own purposes.
-func parseEventUpdateFromKV(ctx context.Context, kve nats.KeyValueEntry,
-	kind rctypes.Kind,
-) (*v1types.ConditionUpdateEvent, error) {
-	parsedKey, err := parseStatusKVKey(kve.Key())
+func parseEventUpdateFromKV(ctx context.Context, kve nats.KeyValueEntry, kind rctypes.Kind) (updEvent *v1types.ConditionUpdateEvent, err error) {
+	var parsedKey *statusKey
+
+	// deferred method collects telemetry on failed kve parse errors
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		var conditionID, serverID string
+		if parsedKey != nil {
+			conditionID = parsedKey.conditionID.String()
+		}
+
+		if updEvent != nil {
+			serverID = updEvent.ServerID.String()
+		}
+
+		metrics.RegisterSpanEventKVParseError(
+			trace.SpanFromContext(ctx),
+			kve.Key(),
+			serverID,
+			conditionID,
+			string(kind),
+			err.Error(),
+		)
+	}()
+
+	parsedKey, err = parseStatusKVKey(kve.Key())
 	if err != nil {
 		return nil, err
 	}
@@ -257,14 +268,15 @@ func parseEventUpdateFromKV(ctx context.Context, kve nats.KeyValueEntry,
 			TraceFlags: trace.FlagsSampled,
 		})
 
-		_, span := otel.Tracer(pkgName).Start(
+		var span trace.Span
+		ctx, span = otel.Tracer(pkgName).Start(
 			trace.ContextWithRemoteSpanContext(ctx, remoteSpan),
-			"eventUpdateFromKV",
+			"parseEventUpdateFromKV",
 		)
 		defer span.End()
 	}
 
-	updEvent := &v1types.ConditionUpdateEvent{
+	updEvent = &v1types.ConditionUpdateEvent{
 		ConditionUpdate: v1types.ConditionUpdate{
 			ConditionID: parsedKey.conditionID,
 			ServerID:    serverID,

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -423,9 +423,8 @@ func (o *Orchestrator) activeConditionsToReconcile(ctx context.Context) ([]*rcty
 	return creates, updates
 }
 
-func (o *Orchestrator) getEventsToReconcile(ctx context.Context) []*v1types.ConditionUpdateEvent {
+func (o *Orchestrator) getEventsToReconcile(ctx context.Context) (evts []*v1types.ConditionUpdateEvent) {
 	// collect all events across multiple condition definitions
-	evts := []*v1types.ConditionUpdateEvent{}
 	for _, def := range o.conditionDefs {
 		kind := def.Kind
 		entries, err := status.GetAllConditions(kind, o.facility)
@@ -630,48 +629,69 @@ func (o *Orchestrator) startReconciler(ctx context.Context, wg *sync.WaitGroup) 
 				keepRunning = false
 
 			case <-ticker.C:
-				// reconcile status KV entries
-				evts := o.getEventsToReconcile(ctx)
-				for _, evt := range evts {
-					le := o.logger.WithFields(logrus.Fields{
-						"conditionID":    evt.ConditionUpdate.ConditionID.String(),
-						"conditionState": string(evt.ConditionUpdate.State),
-						"kind":           string(evt.Kind),
-					})
-
-					if err := o.eventUpdate(ctx, evt); err != nil {
-						le.WithError(err).Warn("reconciler event update")
-						continue
-					}
-
-					le.Info("condition reconciled")
-
-					if err := o.notifier.Send(evt); err != nil {
-						le.WithError(err).Warn("reconciler event notification")
-					}
-				}
-
-				// reconcile active-condition KV entries
-				evts = o.activeConditionsToReconcile(ctx)
-				for _, evt := range evts {
-					le := o.logger.WithFields(logrus.Fields{
-						"conditionID":    evt.ConditionUpdate.ConditionID.String(),
-						"conditionState": string(evt.ConditionUpdate.State),
-						"kind":           string(evt.Kind),
-					})
-
-					if err := o.eventHandler.UpdateCondition(ctx, evt); err != nil {
-						le.WithError(err).Warn("reconciler event update")
-						continue
-					}
-
-					le.Info("condition reconciled")
-
-					if err := o.notifier.Send(evt); err != nil {
-						le.WithError(err).Warn("reconciler event notification")
-					}
-				}
+				o.reconcileStatusKVEntries(ctx)
+				o.reconcileActiveConditionRecords(ctx)
 			}
 		}
 	}()
+}
+
+func (o *Orchestrator) reconcileStatusKVEntries(ctx context.Context) {
+	evts := o.getEventsToReconcile(ctx)
+	for _, evt := range evts {
+		le := o.logger.WithFields(logrus.Fields{
+			"conditionID":    evt.ConditionUpdate.ConditionID.String(),
+			"conditionState": string(evt.ConditionUpdate.State),
+			"kind":           string(evt.Kind),
+		})
+
+		if err := o.eventUpdate(ctx, evt); err != nil {
+			le.WithError(err).Warn("reconciler event update")
+			continue
+		}
+
+		le.Info("condition reconciled")
+
+		if err := o.notifier.Send(evt); err != nil {
+			le.WithError(err).Warn("reconciler event notification")
+		}
+	}
+}
+
+// reconcile active-condition KV entries for missing status KV entries and missing active-condition entries
+func (o *Orchestrator) reconcileActiveConditionRecords(ctx context.Context) {
+	creates, updates := o.activeConditionsToReconcile(ctx)
+	for _, evt := range updates {
+		le := o.logger.WithFields(logrus.Fields{
+			"conditionID":    evt.ConditionUpdate.ConditionID.String(),
+			"conditionState": string(evt.ConditionUpdate.State),
+			"kind":           string(evt.Kind),
+		})
+
+		if err := o.eventHandler.UpdateCondition(ctx, evt); err != nil {
+			le.WithError(err).Warn("reconciler event update")
+			continue
+		}
+
+		le.Info("status KV condition reconciled")
+
+		if err := o.notifier.Send(evt); err != nil {
+			le.WithError(err).Warn("reconciler event notification")
+		}
+	}
+
+	for _, cond := range creates {
+		le := o.logger.WithFields(logrus.Fields{
+			"conditionID":    cond.ID.String(),
+			"conditionState": string(cond.State),
+			"kind":           string(cond.Kind),
+		})
+
+		if err := o.repository.Create(ctx, cond.Target, cond); err != nil {
+			le.WithError(err).Warn("reconciler condition record create")
+			continue
+		}
+
+		le.Info("active-condition KV condition record reconciled")
+	}
 }

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -570,7 +570,7 @@ func (o *Orchestrator) queueFollowingCondition(ctx context.Context, evt *v1types
 // This reconciles conditions in the Condition status KV - $condition.$facility
 func (o *Orchestrator) eventNeedsReconciliation(evt *v1types.ConditionUpdateEvent) bool {
 	// the last update should be later than the condition stale threshold
-	if time.Since(evt.ConditionUpdate.UpdatedAt) < rctypes.StaleThreshold {
+	if time.Since(evt.ConditionUpdate.UpdatedAt) < rcontroller.StatusStaleThreshold {
 		return false
 	}
 

--- a/internal/orchestrator/updates_test.go
+++ b/internal/orchestrator/updates_test.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/metal-toolbox/conditionorc/internal/status"
+	"github.com/metal-toolbox/conditionorc/internal/store"
 	"github.com/nats-io/nats-server/v2/server"
 	srvtest "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.hollow.sh/toolbox/events"
 	"go.hollow.sh/toolbox/events/pkg/kv"
@@ -146,6 +148,109 @@ func TestEventNeedsReconciliation(t *testing.T) {
 
 	evt.ControllerID = liveWorker
 	require.False(t, o.eventNeedsReconciliation(evt), "controller active")
+}
+
+func TestFilterConditionsToReconcile(t *testing.T) {
+	t.Parallel()
+
+	// test condition ID
+	cid1 := uuid.New()
+	// test server ID
+	sid1 := uuid.New()
+
+	tests := []struct {
+		name      string
+		records   []*store.ConditionRecord
+		serverIDs map[string]struct{}
+		want      []*v1types.ConditionUpdateEvent
+	}{
+		{
+			name: "pending in active-conditions, not in status KV",
+			records: []*store.ConditionRecord{
+				{
+					ID:    cid1,
+					State: rctypes.Pending,
+					Conditions: []*rctypes.Condition{
+						{
+							ID:     cid1,
+							Kind:   rctypes.FirmwareInstall,
+							State:  rctypes.Pending,
+							Target: sid1,
+						},
+						{
+							ID:     cid1,
+							Kind:   rctypes.Inventory,
+							State:  rctypes.Pending,
+							Target: sid1,
+						},
+					},
+				},
+			},
+			serverIDs: map[string]struct{}{},
+			want: []*v1types.ConditionUpdateEvent{
+				{
+					ConditionUpdate: v1types.ConditionUpdate{
+						ConditionID: cid1,
+						ServerID:    sid1,
+						State:       rctypes.Failed,
+						Status:      failedByReconciler,
+					},
+					Kind: rctypes.FirmwareInstall,
+				},
+			},
+		},
+		{
+			name: "pending in active-conditions, pending in status KV",
+			records: []*store.ConditionRecord{
+				{
+					ID:    cid1,
+					State: rctypes.Pending,
+					Conditions: []*rctypes.Condition{
+						{
+							ID:     cid1,
+							Kind:   rctypes.FirmwareInstall,
+							State:  rctypes.Pending,
+							Target: sid1,
+						},
+						{
+							ID:     cid1,
+							Kind:   rctypes.Inventory,
+							State:  rctypes.Pending,
+							Target: sid1,
+						},
+					},
+				},
+			},
+			serverIDs: map[string]struct{}{
+				sid1.String(): struct{}{},
+			},
+			want: nil,
+		},
+		{
+			name:    "none pending in active-conditions, pending in status KV",
+			records: nil,
+			serverIDs: map[string]struct{}{
+				sid1.String(): struct{}{},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterConditionsToReconcile(tc.records, tc.serverIDs)
+			if len(tc.want) == 0 {
+				assert.Len(t, got, 0)
+				return
+			}
+
+			assert.WithinDuration(t, time.Now(), got[0].UpdatedAt, 3*time.Second)
+			// zero time value for comparision
+			got[0].UpdatedAt = time.Time{}
+			assert.Equal(t, got, tc.want)
+		})
+	}
+
 }
 
 func TestEventUpdateFromKV(t *testing.T) {

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -63,6 +63,9 @@ type Repository interface {
 	// @serverID: required
 	// @condition: required
 	Update(ctx context.Context, serverID uuid.UUID, condition *rctypes.Condition) error
+
+	// List all condition records
+	List(ctx context.Context) ([]*ConditionRecord, error)
 }
 
 var (

--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -196,9 +196,14 @@ func (n *natsStore) Create(ctx context.Context, serverID uuid.UUID, condition *r
 		"conditionID":   condition.ID.String(),
 	})
 
+	state := rctypes.Pending
+	if condition.State != state {
+		state = condition.State
+	}
+
 	cr := ConditionRecord{
 		ID:    condition.ID,
-		State: rctypes.Pending,
+		State: state,
 		Conditions: []*rctypes.Condition{
 			condition,
 		},

--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -173,6 +173,10 @@ func (n *natsStore) GetActiveCondition(ctx context.Context, serverID uuid.UUID) 
 		}
 	}
 
+	if active == nil {
+		return nil, errors.Wrap(ErrConditionNotFound, "expected an active condition")
+	}
+
 	return active, nil
 }
 

--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -28,6 +28,7 @@ var (
 		kv.WithTTL(10 * 24 * time.Hour), // XXX: we could keep more history here, but might need more storage
 	}
 	errBadData = errors.New("bad condition data")
+	ErrList    = errors.New("list query returned error")
 )
 
 type natsStore struct {
@@ -70,6 +71,7 @@ func (n *natsStore) List(ctx context.Context) ([]*ConditionRecord, error) {
 	found := []*ConditionRecord{}
 	watcher, err := n.bucket.WatchAll(nats.IgnoreDeletes())
 	if err != nil {
+		natsError("bucket.watchAll")
 		return nil, errors.Wrap(err, "error listing all conditions")
 	}
 

--- a/internal/store/nats_test.go
+++ b/internal/store/nats_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 
 	// initialize the bucket here
 	var err error
-	bucket, err = kv.CreateOrBindKVBucket(evJS, bucketName)
+	bucket, err = kv.CreateOrBindKVBucket(evJS, ActiveConditionBucket)
 	if err != nil {
 		logger.WithError(err).Fatal("kv setup")
 	}

--- a/internal/store/test/mock.go
+++ b/internal/store/test/mock.go
@@ -100,6 +100,21 @@ func (mr *MockRepositoryMockRecorder) GetActiveCondition(ctx, serverID interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveCondition", reflect.TypeOf((*MockRepository)(nil).GetActiveCondition), ctx, serverID)
 }
 
+// List mocks base method.
+func (m *MockRepository) List(ctx context.Context) ([]*store.ConditionRecord, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx)
+	ret0, _ := ret[0].([]*store.ConditionRecord)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockRepositoryMockRecorder) List(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockRepository)(nil).List), ctx)
+}
+
 // Update mocks base method.
 func (m *MockRepository) Update(ctx context.Context, serverID uuid.UUID, condition *condition.Condition) error {
 	m.ctrl.T.Helper()

--- a/pkg/api/v1/events/handlers_test.go
+++ b/pkg/api/v1/events/handlers_test.go
@@ -155,6 +155,7 @@ func TestUpdateEvent(t *testing.T) {
 			).Times(1).Return(&rctypes.Condition{
 				ID:     conditionID,
 				Kind:   testKind,
+				Target: serverID,
 				State:  rctypes.Active,
 				Status: []byte(`{ "msg":"still waiting" }`),
 			}, nil),
@@ -197,6 +198,7 @@ func TestUpdateEvent(t *testing.T) {
 			).Times(1).Return(&rctypes.Condition{
 				ID:     conditionID,
 				Kind:   testKind,
+				Target: serverID,
 				State:  rctypes.Active,
 				Status: []byte(`{ "msg":"still waiting" }`),
 			}, nil),

--- a/pkg/api/v1/types/types.go
+++ b/pkg/api/v1/types/types.go
@@ -152,6 +152,7 @@ func (c *ConditionUpdate) MergeExisting(existing *rctypes.Condition) (*rctypes.C
 		Parameters:            existing.Parameters,
 		State:                 c.State,
 		Status:                c.Status,
+		Target:                existing.Target,
 		FailOnCheckpointError: existing.FailOnCheckpointError,
 		UpdatedAt:             c.UpdatedAt,
 		CreatedAt:             existing.CreatedAt,

--- a/pkg/api/v1/types/types.go
+++ b/pkg/api/v1/types/types.go
@@ -73,6 +73,7 @@ type ConditionUpdate struct {
 	State       rctypes.State   `json:"state,omitempty"`
 	Status      json.RawMessage `json:"status,omitempty"`
 	UpdatedAt   time.Time       `json:"updatedAt,omitempty"`
+	CreatedAt   time.Time       `json:"createdAt,omitempty"`
 }
 
 func (c *ConditionUpdate) Validate() error {

--- a/pkg/api/v1/types/types.go
+++ b/pkg/api/v1/types/types.go
@@ -131,19 +131,24 @@ func (c *ConditionUpdateEvent) Validate() error {
 //
 // This method makes sure that update does not overwrite existing data inadvertently.
 func (c *ConditionUpdate) MergeExisting(existing *rctypes.Condition) (*rctypes.Condition, error) {
-	// 1. condition must already exist for update.
+	// condition must already exist for update.
 	if existing == nil {
-		return nil, errBadUpdateTarget
+		return nil, errors.Wrap(errBadUpdateTarget, "existing condition is nil")
 	}
 
+	// condition identifier must match
 	if existing.ID != c.ConditionID {
-		// condition identifier must match
-		return nil, errBadUpdateTarget
+		return nil, errors.Wrap(errBadUpdateTarget, "Condition ID's do not match")
 	}
 
 	// transition is valid
 	if !existing.State.TransitionValid(c.State) {
 		return nil, errInvalidStateTransition
+	}
+
+	// target identifiers must match
+	if existing.Target != c.ServerID {
+		return nil, errors.Wrap(errBadUpdateTarget, "Server ID's do not match")
 	}
 
 	return &rctypes.Condition{

--- a/pkg/api/v1/types/types_test.go
+++ b/pkg/api/v1/types/types_test.go
@@ -72,12 +72,14 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 			&rctypes.Condition{
 				Kind:       rctypes.FirmwareInstall,
 				ID:         uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
+				Target:     uuid.MustParse("f2cd1ef8-c759-4049-905e-f6fdf61719a9"),
 				Parameters: nil,
 				State:      rctypes.Pending,
 				Status:     []byte("{'woo': 'alala'}"),
 			},
 			&rctypes.Condition{
 				ID:         uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
+				Target:     uuid.MustParse("f2cd1ef8-c759-4049-905e-f6fdf61719a9"),
 				Kind:       rctypes.FirmwareInstall,
 				Parameters: nil,
 				State:      rctypes.Active,

--- a/pkg/api/v1/types/types_test.go
+++ b/pkg/api/v1/types/types_test.go
@@ -62,6 +62,25 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 			errBadUpdateTarget,
 		},
 		{
+			"Server ID mismatch error",
+			&ConditionUpdate{
+				ConditionID: uuid.New(),
+				ServerID:    uuid.New(),
+				State:       rctypes.Active,
+				Status:      []byte("{'foo': 'bar'}"),
+			},
+			&rctypes.Condition{
+				ID:         uuid.New(),
+				Target:     uuid.New(),
+				Kind:       rctypes.FirmwareInstall,
+				Parameters: nil,
+				State:      rctypes.Pending,
+				Status:     []byte("{'woo': 'alala'}"),
+			},
+			nil,
+			errBadUpdateTarget,
+		},
+		{
 			"existing merged with update",
 			&ConditionUpdate{
 				ConditionID: uuid.MustParse("48e632e0-d0af-013b-9540-2cde48001122"),
@@ -93,7 +112,7 @@ func TestConditionUpdate_mergeExisting(t *testing.T) {
 			got, err := tt.update.MergeExisting(tt.existing)
 			if tt.wantErr != nil {
 				require.Error(t, err, "no error when one is expected")
-				require.Equal(t, tt.wantErr, err, "error does not match expectation")
+				require.ErrorIs(t, err, tt.wantErr, "error does not match expectation")
 			} else {
 				require.NoError(t, err, "unexpected error")
 				require.Equal(t, tt.want, got, "received does not match expected")


### PR DESCRIPTION
#### What does this PR do

These changes ensures that,

1. The `active-conditions` KV record will be updated for cases where a Condition is not listed in the `$facility.$condition` KV because the Controller isn't running or is malfunctioning such that it cannot publish a status.
2. The `active-condition` record is missing and the Condition's needs to be re-created in the active-conditions.