### PR TITLE
FS-1464: add Target field when creating a condition

### DIFF
--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -203,6 +203,8 @@ func (n *natsStore) Create(ctx context.Context, serverID uuid.UUID, condition *r
 		state = condition.State
 	}
 
+	condition.Target = serverID
+
 	cr := ConditionRecord{
 		ID:    condition.ID,
 		State: state,


### PR DESCRIPTION
It looks we are missing the Target field when creating a condition.

Target remains `00000000-0000-0000-0000-000000000000` which causes [error](https://github.com/metal-toolbox/conditionorc/blob/v1.0.7/pkg/api/v1/types/types.go#L150-L152)