### PR TITLE
Configure chainguard to accept commits signed by GitHub

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,11 @@
+---
+spec:
+  authorities:
+    # Accept all keyless signatures validated from the public sigstore instance.
+    # This is open source software after all. All we want to know is that the
+    # person that did the commit has control over their email address.
+    - keyless:
+        url: https://fulcio.sigstore.dev
+    # Add this if you also want to allow commits signed by GitHub.
+    - key:
+        kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
#### What does this PR do

Configures chainguard to accept GH's internal gpg key that is used to sign web based actions taken by the user (like commits and PR merges).