### PR TITLE
Fix copy/paste error in firmwareInstall() tracing

### DIFF
--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -284,7 +284,7 @@ func (r *Routes) serverEnroll(c *gin.Context) (int, *v1types.ServerResponse) {
 // @Router /servers/{uuid}/firmwareInstall [post]
 func (r *Routes) firmwareInstall(c *gin.Context) (int, *v1types.ServerResponse) {
 	id := c.Param("uuid")
-	otelCtx, span := otel.Tracer(pkgName).Start(c.Request.Context(), "Routes.serverEnroll")
+	otelCtx, span := otel.Tracer(pkgName).Start(c.Request.Context(), "Routes.firmwareInstall")
 	span.SetAttributes(attribute.KeyValue{Key: "serverId", Value: attribute.StringValue(id)})
 	defer span.End()
 


### PR DESCRIPTION
firmwareInstall() had been erroneously reporting itself as serverEnroll(), presumably due to copy/pasted code not getting appropriately modified.

#### What does this PR do

Fixes a tiny copy/paste error in otel tracing for the `/servers/{uuid}/firmwareInstall` endpoint.