### PR TITLE
Sets up orchestrator service routes

### DIFF
--- a/cmd/orchestrator.go
+++ b/cmd/orchestrator.go
@@ -2,16 +2,20 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/equinix-labs/otel-init-go/otelinit"
 
 	"github.com/metal-toolbox/conditionorc/internal/app"
+	"github.com/metal-toolbox/conditionorc/internal/fleetdb"
 	"github.com/metal-toolbox/conditionorc/internal/metrics"
 	"github.com/metal-toolbox/conditionorc/internal/model"
 	"github.com/metal-toolbox/conditionorc/internal/orchestrator"
 	"github.com/metal-toolbox/conditionorc/internal/orchestrator/notify"
+	"github.com/metal-toolbox/conditionorc/internal/server"
 	"github.com/metal-toolbox/conditionorc/internal/store"
 	"github.com/metal-toolbox/conditionorc/internal/version"
 	"github.com/metal-toolbox/rivets/events"
@@ -62,8 +66,38 @@ var cmdOrchestrator = &cobra.Command{
 			app.Logger.Fatal(err)
 		}
 
+		fleetDBClient, err := fleetdb.NewFleetDBClient(ctx, app.Config, app.Config.ConditionDefinitions, app.Logger)
+		if err != nil {
+			app.Logger.Fatal(err)
+		}
+
+		// init Orchestrator API server
+		optionsOrcAPI := []server.Option{
+			server.WithLogger(app.Logger),
+			server.WithListenAddress(app.Config.ListenAddress),
+			server.WithStore(repository),
+			server.WithFleetDBClient(fleetDBClient),
+			server.WithStreamBroker(streamBroker, app.Config.NatsOptions.PublisherSubjectPrefix),
+			server.WithConditionDefinitions(app.Config.ConditionDefinitions),
+			server.WithAsOrchestrator(facility),
+		}
+
+		if app.OidcEnabled() {
+			optionsOrcAPI = append(optionsOrcAPI, server.WithAuthMiddlewareConfig(app.Config.APIServerJWTAuth))
+		}
+
+		app.Logger.Info(version.Current().String())
+
+		srv := server.New(optionsOrcAPI...)
+		go func() {
+			if err := srv.ListenAndServe(); err != nil && errors.Is(err, http.ErrServerClosed) {
+				app.Logger.Fatal(err)
+			}
+		}()
+
 		notifier := notify.New(app.Logger, app.Config.Notifications)
 
+		// init Orchestrator service
 		options := []orchestrator.Option{
 			orchestrator.WithLogger(app.Logger),
 			orchestrator.WithListenAddress(app.Config.ListenAddress),
@@ -85,6 +119,13 @@ var cmdOrchestrator = &cobra.Command{
 
 		orc := orchestrator.New(options...)
 		orc.Run(ctx)
+
+		// shutdown server when orchestrator Run method returns
+		ctx, cancel := context.WithTimeout(cmd.Context(), shutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			app.Logger.Fatal("server shutdown error:", err)
+		}
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/metal-toolbox/conditionorc/internal/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.hollow.sh/toolbox/ginjwt"
 )
 
 var (
@@ -48,4 +50,7 @@ func init() {
 	// Read in env vars with appName as prefix
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "conditionorc.yaml", "default is ./conditionorc.yaml")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "set logging level - debug, trace")
+
+	rootCmd.PersistentFlags().Bool("oidc", true, "Use OIDC Auth for API endpoints")
+	ginjwt.BindFlagFromViperInst(viper.GetViper(), "oidc.enabled", rootCmd.PersistentFlags().Lookup("oidc"))
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,8 +18,6 @@ import (
 	"github.com/metal-toolbox/conditionorc/internal/version"
 	"github.com/metal-toolbox/rivets/events"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.hollow.sh/toolbox/ginjwt"
 )
 
 var shutdownTimeout = 10 * time.Second
@@ -67,19 +65,12 @@ var cmdServer = &cobra.Command{
 			server.WithListenAddress(app.Config.ListenAddress),
 			server.WithStore(repository),
 			server.WithFleetDBClient(fleetDBClient),
-			server.WithStreamBroker(streamBroker),
+			server.WithStreamBroker(streamBroker, app.Config.NatsOptions.PublisherSubjectPrefix),
 			server.WithConditionDefinitions(app.Config.ConditionDefinitions),
 		}
 
-		if viper.GetViper().GetBool("oidc.enabled") {
-			if len(app.Config.APIServerJWTAuth) == 0 {
-				app.Logger.Fatal("OIDC enabled without configuration")
-			}
-
+		if app.OidcEnabled() {
 			options = append(options, server.WithAuthMiddlewareConfig(app.Config.APIServerJWTAuth))
-			app.Logger.Info("OIDC enabled")
-		} else {
-			app.Logger.Info("OIDC disabled")
 		}
 
 		app.Logger.Info(version.Current().String())
@@ -109,6 +100,4 @@ var cmdServer = &cobra.Command{
 // install command flags
 func init() {
 	rootCmd.AddCommand(cmdServer)
-	cmdServer.Flags().Bool("oidc", true, "use oidc auth")
-	ginjwt.BindFlagFromViperInst(viper.GetViper(), "oidc.enabled", cmdServer.Flags().Lookup("oidc"))
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -101,6 +101,20 @@ func (a *App) LoadConfiguration() error {
 	return nil
 }
 
+func (a *App) OidcEnabled() bool {
+	if a.v.GetBool("oidc.enabled") {
+		if len(a.Config.APIServerJWTAuth) == 0 {
+			a.Logger.Fatal("OIDC enabled without configuration")
+		}
+		a.Logger.Info("OIDC enabled")
+
+		return true
+	}
+
+	a.Logger.Info("OIDC disabled")
+	return false
+}
+
 func (a *App) envVarOverrides() error {
 	if a.v.GetString("log.level") != "" {
 		a.Config.LogLevel = a.v.GetString("log.level")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,11 +31,13 @@ var (
 
 // Server type holds attributes of the condition orc server
 type Server struct {
-	// Logger is the app logger
+	orchestrator         bool // run in orchestrator API mode
 	authMWConfigs        []ginjwt.AuthConfig
 	logger               *logrus.Logger
 	streamBroker         events.Stream
+	streamSubjectPrefix  string
 	listenAddress        string
+	facilityCode         string
 	conditionDefinitions rctypes.Definitions
 	repository           store.Repository
 	fleetDBClient        fleetdb.FleetDB
@@ -73,9 +75,10 @@ func WithListenAddress(addr string) Option {
 }
 
 // WithStreamBroker sets the event stream broker.
-func WithStreamBroker(broker events.Stream) Option {
+func WithStreamBroker(broker events.Stream, streamSubjectPrefix string) Option {
 	return func(s *Server) {
 		s.streamBroker = broker
+		s.streamSubjectPrefix = streamSubjectPrefix
 	}
 }
 
@@ -90,6 +93,14 @@ func WithConditionDefinitions(defs rctypes.Definitions) Option {
 func WithAuthMiddlewareConfig(authMWConfigs []ginjwt.AuthConfig) Option {
 	return func(s *Server) {
 		s.authMWConfigs = authMWConfigs
+	}
+}
+
+// WithAsOrchestrator registers just the Orchestrator routes, excluding any Condition API routes.
+func WithAsOrchestrator(facilityCode string) Option {
+	return func(s *Server) {
+		s.orchestrator = true
+		s.facilityCode = facilityCode
 	}
 }
 
@@ -109,8 +120,13 @@ func New(opts ...Option) *http.Server {
 		routes.WithLogger(s.logger),
 		routes.WithStore(s.repository),
 		routes.WithFleetDBClient(s.fleetDBClient),
-		routes.WithStreamBroker(s.streamBroker),
+		routes.WithStreamBroker(s.streamBroker, s.streamSubjectPrefix),
 		routes.WithConditionDefinitions(s.conditionDefinitions),
+	}
+
+	// orchestrator mode requires a facility code
+	if s.orchestrator {
+		options = append(options, routes.WithFacilityCode(s.facilityCode))
 	}
 
 	// add auth middleware
@@ -128,7 +144,13 @@ func New(opts ...Option) *http.Server {
 		s.logger.Fatal(errors.Wrap(err, ErrRoutes.Error()))
 	}
 
-	v1Router.Routes(g.Group(routes.PathPrefix))
+	if s.orchestrator {
+		v1Router.RoutesOrchestrator(g.Group(routes.PathPrefix))
+		s.logger.Info("Orchestrator API server routes registered.")
+	} else {
+		v1Router.Routes(g.Group(routes.PathPrefix))
+		s.logger.Info("Condition API server routes registered.")
+	}
 
 	g.NoRoute(func(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"message": "invalid request - route not found"})

--- a/pkg/api/v1/client/client_test.go
+++ b/pkg/api/v1/client/client_test.go
@@ -70,7 +70,7 @@ func newTester(t *testing.T) *integrationTester {
 		server.WithListenAddress("localhost:9999"),
 		server.WithStore(repository),
 		server.WithFleetDBClient(fleetDBClient),
-		server.WithStreamBroker(stream),
+		server.WithStreamBroker(stream, "foo"),
 		server.WithConditionDefinitions(
 			[]*rctypes.Definition{
 				{Kind: rctypes.FirmwareInstall},

--- a/pkg/api/v1/routes/handlers_test.go
+++ b/pkg/api/v1/routes/handlers_test.go
@@ -45,7 +45,7 @@ func mockserver(t *testing.T, logger *logrus.Logger, fleetDBClient fleetdb.Fleet
 	}
 
 	if stream != nil {
-		options = append(options, WithStreamBroker(stream))
+		options = append(options, WithStreamBroker(stream, "foo"))
 	}
 
 	v1Router, err := NewRoutes(options...)


### PR DESCRIPTION
#### What does this PR do

- Moves the oidc auth enable parameter as a top level flag for reuse
- Sets up the Orchestrator API router

Changes merge into the `fw-inband-devel` branch which will track `main` until all changes are merged into this devel branch. 