### PR TITLE
[FS-1568]Add the draft server provision api

### DIFF
--- a/pkg/api/v1/conditions/routes/handlers.go
+++ b/pkg/api/v1/conditions/routes/handlers.go
@@ -269,6 +269,26 @@ func (r *Routes) serverEnroll(c *gin.Context) (int, *v1types.ServerResponse) {
 	return st, resp
 }
 
+// @Summary Server Provision
+// @Tag Servers
+// @Description an API to perform the server provision.
+// @Accept json
+// @Produce json
+// @Success 200 {object} v1types.ServerResponse
+// @Router /serverProvision [post]
+func (r *Routes) serverProvision(c *gin.Context) (int, *v1types.ServerResponse) {
+	var sp v1types.ServerProvisionRequest
+	if err := c.ShouldBindJSON(&sp); err != nil {
+		r.logger.WithError(err).Warn("unmarshal server provision payload")
+
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid server provision payload: " + err.Error(),
+		}
+	}
+
+	return 501, &v1types.ServerResponse{Message: "unimplemented"}
+}
+
 // @Summary Firmware Install
 // @Tag Conditions
 // @Description Installs firmware on a device and validates with a subsequent inventory

--- a/pkg/api/v1/conditions/routes/routes.go
+++ b/pkg/api/v1/conditions/routes/routes.go
@@ -138,6 +138,9 @@ func (r *Routes) composeAuthHandler(scopes []string) gin.HandlerFunc {
 
 // Routes returns routes for the Conditions API service.
 func (r *Routes) Routes(g *gin.RouterGroup) {
+	// API for server provision
+	g.POST("/serverProvision", r.composeAuthHandler(createScopes("server")), wrapAPICall(r.serverProvision))
+
 	servers := g.Group("/servers/:uuid")
 
 	serverEnroll := g.Group("/serverEnroll")

--- a/pkg/api/v1/conditions/types/types.go
+++ b/pkg/api/v1/conditions/types/types.go
@@ -183,5 +183,4 @@ type ServerProvisionRequest struct {
 	StorageConfiguration string    `json:"StorageConfiguration,omitempty"`
 	NetworkConfiguration string    `json:"NetworkConfiguration,omitempty"`
 	Tags                 []string  `json:"Tags,omitempty"`
-	State                string    `json:"State,omitempty"`
 }

--- a/pkg/api/v1/conditions/types/types.go
+++ b/pkg/api/v1/conditions/types/types.go
@@ -170,3 +170,19 @@ func (c *ConditionUpdateEvent) MergeExisting(existing *rctypes.Condition) (*rcty
 		CreatedAt:             existing.CreatedAt,
 	}, nil
 }
+
+// ServerProvisionRequest is the request payload to provision a server.
+// Duplicated from FCP without Spec: https://github.com/equinixmetal/facility-controlplane/blob/main/pkg/api/v1/types.go#L388-L402
+type ServerProvisionRequest struct {
+	ServerID             uuid.UUID `json:"serverID,omitempty"`
+	InstanceID           uuid.UUID `json:"instanceID,omitempty"`
+	Hostname             string    `json:"Hostname,omitempty"`
+	ProviderType         string    `json:"ProviderType,omitempty"`
+	OperatingSystemID    string    `json:"OperatingSystemID,omitempty"`
+	InfrastructureID     []string  `json:"InfrastructureID,omitempty"`
+	UserData             *string   `json:"UserData,omitempty"`
+	StorageConfiguration *string   `json:"StorageConfiguration,omitempty"`
+	NetworkConfiguration *string   `json:"NetworkConfiguration,omitempty"`
+	Tags                 *[]string `json:"Tags,omitempty"`
+	State                string    `json:"State,omitempty"`
+}

--- a/pkg/api/v1/conditions/types/types.go
+++ b/pkg/api/v1/conditions/types/types.go
@@ -179,10 +179,9 @@ type ServerProvisionRequest struct {
 	Hostname             string    `json:"Hostname,omitempty"`
 	ProviderType         string    `json:"ProviderType,omitempty"`
 	OperatingSystemID    string    `json:"OperatingSystemID,omitempty"`
-	InfrastructureID     []string  `json:"InfrastructureID,omitempty"`
-	UserData             *string   `json:"UserData,omitempty"`
-	StorageConfiguration *string   `json:"StorageConfiguration,omitempty"`
-	NetworkConfiguration *string   `json:"NetworkConfiguration,omitempty"`
-	Tags                 *[]string `json:"Tags,omitempty"`
+	UserData             string    `json:"UserData,omitempty"`
+	StorageConfiguration string    `json:"StorageConfiguration,omitempty"`
+	NetworkConfiguration string    `json:"NetworkConfiguration,omitempty"`
+	Tags                 []string  `json:"Tags,omitempty"`
 	State                string    `json:"State,omitempty"`
 }


### PR DESCRIPTION
#### What does this PR do
This is the placeholder for server provision api. Will throw an error since the API is unimplemented.
tested locally with
```
% curl -i -X POST --header 'Content-Type: application/json' localhost:9001/api/v1/serverProvision -d ""
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8
Date: Fri, 19 Jul 2024 05:54:55 GMT
Content-Length: 51

{"message":"invalid server provision payload: EOF"}% 
```
cc @iancoffey

