### PR TITLE
add an API to kick off validation

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -38,7 +38,27 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/serverProvision": {
+            "post": {
+                "description": "an API to perform the server provision.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Server Provision",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -61,7 +81,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -97,7 +117,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -135,7 +155,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -165,7 +185,38 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/validateFirmware": {
+            "post": {
+                "description": "Initiates a firmware install, an inventory, and a firmware validation in a single workflow.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Validate Firmware",
+                "parameters": [
+                    {
+                        "description": "firmware validation options: server id and firmware set id",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.FirmwareValidationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -183,10 +234,6 @@ const docTemplate = `{
                 "createdAt": {
                     "description": "CreatedAt is when this object was created.",
                     "type": "string"
-                },
-                "exclusive": {
-                    "description": "Exclusive indicates this condition holds exclusive access to the device\nand other conditions have to wait until this is in a finalized state.",
-                    "type": "boolean"
                 },
                 "failOnCheckpointError": {
                     "description": "Should the worker executing this condition fail if its unable to checkpoint\nthe status of work on this condition.",
@@ -233,6 +280,10 @@ const docTemplate = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "target": {
+                    "description": "Target is the identifier for the target server this Condition is applicable for.",
+                    "type": "string"
                 },
                 "updatedAt": {
                     "description": "UpdatedAt is when this object was last updated.",
@@ -332,14 +383,26 @@ const docTemplate = `{
         "condition.Kind": {
             "type": "string",
             "enum": [
-                "inventory",
+                "broker",
+                "broker.acquireServer",
+                "broker.releaseServer",
                 "virtualMediaMount",
-                "firmwareInstall"
+                "firmwareInstall",
+                "firmwareInstallInband",
+                "inventory",
+                "serverControl",
+                "biosControl"
             ],
             "x-enum-varnames": [
-                "Inventory",
+                "Broker",
+                "BrokerAcquireServer",
+                "BrokerReleaseServer",
                 "VirtualMediaMount",
-                "FirmwareInstall"
+                "FirmwareInstall",
+                "FirmwareInstallInband",
+                "Inventory",
+                "ServerControl",
+                "BiosControl"
             ]
         },
         "condition.State": {
@@ -357,6 +420,35 @@ const docTemplate = `{
                 "Succeeded"
             ]
         },
+        "github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "records": {
+                    "$ref": "#/definitions/types.ConditionsResponse"
+                },
+                "statusCode": {
+                    "type": "integer"
+                }
+            }
+        },
+        "routes.FirmwareValidationRequest": {
+            "type": "object",
+            "required": [
+                "firmware_set_id",
+                "server_id"
+            ],
+            "properties": {
+                "firmware_set_id": {
+                    "type": "string"
+                },
+                "server_id": {
+                    "type": "string"
+                }
+            }
+        },
         "types.ConditionsResponse": {
             "type": "object",
             "properties": {
@@ -371,20 +463,6 @@ const docTemplate = `{
                 },
                 "state": {
                     "$ref": "#/definitions/condition.State"
-                }
-            }
-        },
-        "types.ServerResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "records": {
-                    "$ref": "#/definitions/types.ConditionsResponse"
-                },
-                "statusCode": {
-                    "type": "integer"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -30,7 +30,27 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/serverProvision": {
+            "post": {
+                "description": "an API to perform the server provision.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Server Provision",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -53,7 +73,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -89,7 +109,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -127,7 +147,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -157,7 +177,38 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.ServerResponse"
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/validateFirmware": {
+            "post": {
+                "description": "Initiates a firmware install, an inventory, and a firmware validation in a single workflow.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Validate Firmware",
+                "parameters": [
+                    {
+                        "description": "firmware validation options: server id and firmware set id",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.FirmwareValidationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse"
                         }
                     }
                 }
@@ -175,10 +226,6 @@
                 "createdAt": {
                     "description": "CreatedAt is when this object was created.",
                     "type": "string"
-                },
-                "exclusive": {
-                    "description": "Exclusive indicates this condition holds exclusive access to the device\nand other conditions have to wait until this is in a finalized state.",
-                    "type": "boolean"
                 },
                 "failOnCheckpointError": {
                     "description": "Should the worker executing this condition fail if its unable to checkpoint\nthe status of work on this condition.",
@@ -225,6 +272,10 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "target": {
+                    "description": "Target is the identifier for the target server this Condition is applicable for.",
+                    "type": "string"
                 },
                 "updatedAt": {
                     "description": "UpdatedAt is when this object was last updated.",
@@ -324,14 +375,26 @@
         "condition.Kind": {
             "type": "string",
             "enum": [
-                "inventory",
+                "broker",
+                "broker.acquireServer",
+                "broker.releaseServer",
                 "virtualMediaMount",
-                "firmwareInstall"
+                "firmwareInstall",
+                "firmwareInstallInband",
+                "inventory",
+                "serverControl",
+                "biosControl"
             ],
             "x-enum-varnames": [
-                "Inventory",
+                "Broker",
+                "BrokerAcquireServer",
+                "BrokerReleaseServer",
                 "VirtualMediaMount",
-                "FirmwareInstall"
+                "FirmwareInstall",
+                "FirmwareInstallInband",
+                "Inventory",
+                "ServerControl",
+                "BiosControl"
             ]
         },
         "condition.State": {
@@ -349,6 +412,35 @@
                 "Succeeded"
             ]
         },
+        "github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "records": {
+                    "$ref": "#/definitions/types.ConditionsResponse"
+                },
+                "statusCode": {
+                    "type": "integer"
+                }
+            }
+        },
+        "routes.FirmwareValidationRequest": {
+            "type": "object",
+            "required": [
+                "firmware_set_id",
+                "server_id"
+            ],
+            "properties": {
+                "firmware_set_id": {
+                    "type": "string"
+                },
+                "server_id": {
+                    "type": "string"
+                }
+            }
+        },
         "types.ConditionsResponse": {
             "type": "object",
             "properties": {
@@ -363,20 +455,6 @@
                 },
                 "state": {
                     "$ref": "#/definitions/condition.State"
-                }
-            }
-        },
-        "types.ServerResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "records": {
-                    "$ref": "#/definitions/types.ConditionsResponse"
-                },
-                "statusCode": {
-                    "type": "integer"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,11 +8,6 @@ definitions:
       createdAt:
         description: CreatedAt is when this object was created.
         type: string
-      exclusive:
-        description: |-
-          Exclusive indicates this condition holds exclusive access to the device
-          and other conditions have to wait until this is in a finalized state.
-        type: boolean
       failOnCheckpointError:
         description: |-
           Should the worker executing this condition fail if its unable to checkpoint
@@ -48,6 +43,10 @@ definitions:
         items:
           type: integer
         type: array
+      target:
+        description: Target is the identifier for the target server this Condition
+          is applicable for.
+        type: string
       updatedAt:
         description: UpdatedAt is when this object was last updated.
         type: string
@@ -129,14 +128,26 @@ definitions:
     type: object
   condition.Kind:
     enum:
-    - inventory
+    - broker
+    - broker.acquireServer
+    - broker.releaseServer
     - virtualMediaMount
     - firmwareInstall
+    - firmwareInstallInband
+    - inventory
+    - serverControl
+    - biosControl
     type: string
     x-enum-varnames:
-    - Inventory
+    - Broker
+    - BrokerAcquireServer
+    - BrokerReleaseServer
     - VirtualMediaMount
     - FirmwareInstall
+    - FirmwareInstallInband
+    - Inventory
+    - ServerControl
+    - BiosControl
   condition.State:
     enum:
     - pending
@@ -149,6 +160,25 @@ definitions:
     - Active
     - Failed
     - Succeeded
+  github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse:
+    properties:
+      message:
+        type: string
+      records:
+        $ref: '#/definitions/types.ConditionsResponse'
+      statusCode:
+        type: integer
+    type: object
+  routes.FirmwareValidationRequest:
+    properties:
+      firmware_set_id:
+        type: string
+      server_id:
+        type: string
+    required:
+    - firmware_set_id
+    - server_id
+    type: object
   types.ConditionsResponse:
     properties:
       conditions:
@@ -159,15 +189,6 @@ definitions:
         type: string
       state:
         $ref: '#/definitions/condition.State'
-    type: object
-  types.ServerResponse:
-    properties:
-      message:
-        type: string
-      records:
-        $ref: '#/definitions/types.ConditionsResponse'
-      statusCode:
-        type: integer
     type: object
 info:
   contact: {}
@@ -194,8 +215,21 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.ServerResponse'
+            $ref: '#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse'
       summary: Server Enroll
+  /serverProvision:
+    post:
+      consumes:
+      - application/json
+      description: an API to perform the server provision.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse'
+      summary: Server Provision
   /servers/{uuid}:
     delete:
       description: |-
@@ -211,7 +245,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.ServerResponse'
+            $ref: '#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse'
       summary: Server Delete
   /servers/{uuid}/condition/{conditionKind}:
     post:
@@ -237,7 +271,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.ServerResponse'
+            $ref: '#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse'
       summary: Condition Create
   /servers/{uuid}/firmwareInstall:
     post:
@@ -264,7 +298,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.ServerResponse'
+            $ref: '#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse'
       summary: Firmware Install
   /servers/{uuid}/status:
     get:
@@ -284,6 +318,27 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.ServerResponse'
+            $ref: '#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse'
       summary: Condition Status
+  /validateFirmware:
+    post:
+      consumes:
+      - application/json
+      description: Initiates a firmware install, an inventory, and a firmware validation
+        in a single workflow.
+      parameters:
+      - description: 'firmware validation options: server id and firmware set id'
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/routes.FirmwareValidationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_metal-toolbox_conditionorc_pkg_api_v1_conditions_types.ServerResponse'
+      summary: Validate Firmware
 swagger: "2.0"

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -46,8 +46,7 @@ type Repository interface {
 	// @serverID: required
 	Get(ctx context.Context, serverID uuid.UUID) (*ConditionRecord, error)
 
-	// Get the currently active condition. If there is nothing active, return nil. Errors only
-	// when the underlying storage is unavailable
+	// Get the currently active condition. If there is nothing active, return ErrNoConditionFound.
 	// @serverID: required
 	GetActiveCondition(ctx context.Context, serverID uuid.UUID) (*rctypes.Condition, error)
 

--- a/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
+++ b/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
@@ -1,0 +1,143 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	rctypes "github.com/metal-toolbox/rivets/condition"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/metal-toolbox/conditionorc/internal/metrics"
+	"github.com/metal-toolbox/conditionorc/internal/store"
+	v1types "github.com/metal-toolbox/conditionorc/pkg/api/v1/conditions/types"
+)
+
+type FirmwareValidationRequest struct {
+	ServerID      uuid.UUID `json:"server_id" binding:"required,uuid4_rfc4122"`
+	FirmwareSetID uuid.UUID `json:"firmware_set_id" binding:"required,uuid4_rfc4122"`
+}
+
+func (fvr FirmwareValidationRequest) AsJSON() (json.RawMessage, error) {
+	return json.Marshal(fvr)
+}
+
+// this is where we compose all conditions to be executed during the firmware validation task
+func firmwareValidationConditions(fvr FirmwareValidationRequest) *rctypes.ServerConditions {
+	createTime := time.Now()
+
+	fwParams := &rctypes.FirmwareInstallTaskParameters{
+		FirmwareSetID:         fvr.FirmwareSetID,
+		AssetID:               fvr.ServerID,
+		ResetBMCBeforeInstall: true,
+	}
+
+	return &rctypes.ServerConditions{
+		ServerID: fvr.ServerID,
+		Conditions: []*rctypes.Condition{
+			{
+				Kind:       rctypes.FirmwareInstall,
+				Version:    rctypes.ConditionStructVersion,
+				Parameters: fwParams.MustJSON(),
+				State:      rctypes.Pending,
+				CreatedAt:  createTime,
+			},
+			{
+				Kind:       rctypes.Inventory,
+				Version:    rctypes.ConditionStructVersion,
+				Parameters: rctypes.MustDefaultInventoryJSON(fvr.ServerID),
+				State:      rctypes.Pending,
+				CreatedAt:  createTime,
+			},
+			// TODO: Need a firmware validation task, but first things first!
+		},
+	}
+}
+
+// @Summary Validate Firmware
+// @Tag Conditions
+// @Description Initiates a firmware install, an inventory, and a firmware validation in a single workflow.
+// @Param data body FirmwareValidationRequest true "firmware validation options: server id and firmware set id"
+// @Accept json
+// @Produce json
+// @Success 200 {object} v1types.ServerResponse
+// Failure 400 {object} v1types.ServerResponse
+// Failure 403 {object} v1types.ServerResponse
+// Failure 409 {object} v1types.ServerResponse
+// Failure 503 {object} v1types.ServerResponse
+// @Router /validateFirmware [post]
+func (r *Routes) validateFirmware(c *gin.Context) (int, *v1types.ServerResponse) {
+	otelCtx, span := otel.Tracer(pkgName).Start(c.Request.Context(), "Routes.validateFirmware")
+	defer span.End()
+
+	var fvr FirmwareValidationRequest
+	if err := c.ShouldBindJSON(&fvr); err != nil {
+		r.logger.WithError(err).Warn("unmarshal firmware validation payload")
+
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "invalid firmware validation payload: " + err.Error(),
+		}
+	}
+
+	facilityCode, err := r.serverFacilityCode(otelCtx, fvr.ServerID)
+	if err != nil {
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: "server facility: " + err.Error(),
+		}
+	}
+
+	span.SetAttributes(
+		attribute.KeyValue{Key: "serverId", Value: attribute.StringValue(fvr.ServerID.String())},
+		attribute.KeyValue{Key: "firmwareSet", Value: attribute.StringValue(fvr.ServerID.String())},
+		attribute.KeyValue{Key: "facility", Value: attribute.StringValue(facilityCode)},
+	)
+
+	conds := firmwareValidationConditions(fvr)
+	// XXX: This is lifted from the firmwareInstall api code. Consider abstracting a utility method for
+	// CreateMultiple and publishCondition.
+	if err = r.repository.CreateMultiple(otelCtx, fvr.ServerID, facilityCode, conds.Conditions...); err != nil {
+		if errors.Is(err, store.ErrActiveCondition) {
+			return http.StatusConflict, &v1types.ServerResponse{
+				Message: err.Error(),
+			}
+		}
+
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: "scheduling condition: " + err.Error(),
+		}
+	}
+
+	if err = r.publishCondition(otelCtx, fvr.ServerID, facilityCode, conds.Conditions[0]); err != nil {
+		r.logger.WithField("kind", conds.Conditions[0].Kind).WithError(err).Warn("error publishing condition")
+		// mark first condition as failed
+		conds.Conditions[0].State = rctypes.Failed
+		conds.Conditions[0].Status = failedPublishStatus
+
+		if markErr := r.repository.Update(otelCtx, fvr.ServerID, conds.Conditions[0]); markErr != nil {
+			// an operator is going to have to sort this out
+			r.logger.WithError(err).Warn("marking unpublished condition failed")
+		}
+		return http.StatusInternalServerError, &v1types.ServerResponse{
+			Message: "publishing condition" + err.Error(),
+		}
+	}
+
+	metrics.ConditionQueued.With(
+		// XXX: define a Kind for firmwareValidation
+		prometheus.Labels{"conditionKind": string(rctypes.FirmwareInstall)},
+	).Inc()
+
+	return http.StatusOK, &v1types.ServerResponse{
+		Message: "firmware validation scheduled",
+		Records: &v1types.ConditionsResponse{
+			ServerID:   fvr.ServerID,
+			State:      rctypes.Pending,
+			Conditions: conds.Conditions,
+		},
+	}
+}

--- a/pkg/api/v1/conditions/routes/firmware_validation_handlers_test.go
+++ b/pkg/api/v1/conditions/routes/firmware_validation_handlers_test.go
@@ -1,0 +1,156 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/metal-toolbox/conditionorc/internal/model"
+	"github.com/metal-toolbox/conditionorc/internal/store"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	fwValidationUrl string = "/api/v1/validateFirmware"
+)
+
+func TestValidateFirmware(t *testing.T) {
+	t.Parallel()
+	t.Run("bogus request", func(t *testing.T) {
+		t.Parallel()
+		//repo, fleetdb, stream, server, err := setupTestServer(t)
+		_, _, _, server, err := setupTestServer(t)
+		require.NoError(t, err, "prerequisite setup")
+		payload := []byte(`{"msg": "this is not a valid firmware validation request"}`)
+
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(payload))
+		require.NoError(t, err, "creating http POST request")
+
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusBadRequest, recorder.Code, "returned payload: %s", string(asBytes(t, recorder.Body)))
+	})
+	t.Run("bad facility lookup", func(t *testing.T) {
+		t.Parallel()
+		_, fleetdb, _, server, err := setupTestServer(t)
+		require.NoError(t, err, "prerequisite setup")
+
+		fvr, err := FirmwareValidationRequest{
+			ServerID:      uuid.New(),
+			FirmwareSetID: uuid.New(),
+		}.AsJSON()
+		require.NoError(t, err, "creating validation request")
+
+		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(nil, errors.New("pound sand"))
+
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(fvr))
+		require.NoError(t, err, "creating http POST request")
+
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusInternalServerError, recorder.Code, "returned payload: %s", string(asBytes(t, recorder.Body)))
+	})
+	t.Run("create conditions error", func(t *testing.T) {
+		t.Parallel()
+		repo, fleetdb, _, server, err := setupTestServer(t)
+		require.NoError(t, err, "prerequisite setup")
+
+		srv := &model.Server{
+			ID:           uuid.New(),
+			FacilityCode: "fc13",
+		}
+
+		fvr, err := FirmwareValidationRequest{
+			ServerID:      srv.ID,
+			FirmwareSetID: uuid.New(),
+		}.AsJSON()
+		require.NoError(t, err, "creating validation request")
+
+		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Twice()
+		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+			Return(store.ErrActiveCondition).Once()
+		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+			Return(errors.New("pound sand")).Once()
+
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(fvr))
+		require.NoError(t, err, "creating first http POST request")
+
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusConflict, recorder.Code, "returned payload: %s", string(asBytes(t, recorder.Body)))
+
+		req, err = http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(fvr))
+		require.NoError(t, err, "creating second http POST request")
+
+		recorder = httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusInternalServerError, recorder.Code, "returned payload: %s", string(asBytes(t, recorder.Body)))
+	})
+	t.Run("publish conditions error", func(t *testing.T) {
+		t.Parallel()
+		repo, fleetdb, stream, server, err := setupTestServer(t)
+		require.NoError(t, err, "prerequisite setup")
+
+		srv := &model.Server{
+			ID:           uuid.New(),
+			FacilityCode: "fc13",
+		}
+
+		fvr, err := FirmwareValidationRequest{
+			ServerID:      srv.ID,
+			FirmwareSetID: uuid.New(),
+		}.AsJSON()
+		require.NoError(t, err, "creating validation request")
+
+		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Once()
+
+		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+			Return(nil).Once()
+		repo.On("Update", mock.Anything, srv.ID, mock.Anything).Return(nil).Once()
+
+		stream.On("Publish", mock.Anything, "fc13.servers.firmwareInstall", mock.Anything).
+			Return(errors.New("no can do")).Once()
+
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(fvr))
+		require.NoError(t, err, "creating http POST request")
+
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusInternalServerError, recorder.Code, "returned payload: %s", string(asBytes(t, recorder.Body)))
+	})
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		repo, fleetdb, stream, server, err := setupTestServer(t)
+		require.NoError(t, err, "prerequisite setup")
+
+		srv := &model.Server{
+			ID:           uuid.New(),
+			FacilityCode: "fc13",
+		}
+
+		fvr, err := FirmwareValidationRequest{
+			ServerID:      srv.ID,
+			FirmwareSetID: uuid.New(),
+		}.AsJSON()
+		require.NoError(t, err, "creating validation request")
+
+		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Once()
+
+		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+			Return(nil).Once()
+
+		stream.On("Publish", mock.Anything, "fc13.servers.firmwareInstall", mock.Anything).Return(nil).Once()
+
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(fvr))
+		require.NoError(t, err, "creating http POST request")
+
+		recorder := httptest.NewRecorder()
+		server.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusOK, recorder.Code, "returned payload: %s", string(asBytes(t, recorder.Body)))
+	})
+}

--- a/pkg/api/v1/conditions/routes/routes.go
+++ b/pkg/api/v1/conditions/routes/routes.go
@@ -168,6 +168,11 @@ func (r *Routes) Routes(g *gin.RouterGroup) {
 			r.composeAuthHandler(createScopes("condition")),
 			wrapAPICall(r.serverConditionCreate))
 	}
+
+	// fwValidate as a group doesn't assume you know a server that you want to act on. It is in the payload
+	// in the first iteration but is not intended to be a parameter forever.
+	fwValidate := g.Group("/validateFirmware")
+	fwValidate.POST("", r.composeAuthHandler(createScopes("condition")), wrapAPICall(r.validateFirmware))
 }
 
 func createScopes(items ...string) []string {


### PR DESCRIPTION
This API creates a workflow for Firmware Validation. Currently it only replicates `firmwareInstall` as there is no actual controller for firmware validation yet, but adding such should be straightforward. I also added swagger annotations and regenerated the docs.
