### PR TITLE
Reconcile unlinked events fixes

### DIFF
--- a/internal/fleetdb/fleetdb.go
+++ b/internal/fleetdb/fleetdb.go
@@ -179,6 +179,12 @@ func (i *fleetDBImpl) WriteEventHistory(ctx context.Context, cond *rctypes.Condi
 		lastUpdate = time.Now()
 	}
 
+	createdTS := cond.CreatedAt
+	if createdTS.IsZero() {
+		le.Error("created time is zero")
+		createdTS = lastUpdate
+	}
+
 	evt := &fleetdbapi.Event{
 		EventID:     cond.ID,
 		Type:        string(cond.Kind),

--- a/internal/fleetdb/fleetdb.go
+++ b/internal/fleetdb/fleetdb.go
@@ -180,9 +180,11 @@ func (i *fleetDBImpl) WriteEventHistory(ctx context.Context, cond *rctypes.Condi
 	}
 
 	createdTS := cond.CreatedAt
+
 	if createdTS.IsZero() {
-		le.Error("created time is zero")
-		createdTS = lastUpdate
+		errCreatedAt := errors.New("condition createdAt value is zero")
+		le.Error(errCreatedAt)
+		return errCreatedAt
 	}
 
 	evt := &fleetdbapi.Event{

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -806,6 +806,7 @@ func (o *Orchestrator) reconcileActiveConditionRecords(ctx context.Context) {
 			if rctypes.StateIsComplete(cond.State) {
 				if histErr := o.db.WriteEventHistory(ctx, cond); histErr != nil {
 					le.WithError(histErr).Warn("writing event history for unlinked condition")
+					metrics.DependencyError("fleetdb", "update event history")
 				}
 			}
 			if delErr := status.DeleteCondition(cond.Kind, o.facility, cond.ID.String()); delErr != nil {

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -805,6 +805,11 @@ func (o *Orchestrator) reconcileActiveConditionRecords(ctx context.Context) {
 			// a newer condition was queued after the failure that caused this one to need reconciliation
 			// don't do anything more here, it will only confuse things
 			le.WithField("current.ID", lastCR.ID.String()).Info("more recent condition found")
+			if rctypes.StateIsComplete(cond.State) {
+				if histErr := o.db.WriteEventHistory(ctx, cond); histErr != nil {
+					le.WithError(histErr).Warn("writing event history for unlinked condition")
+				}
+			}
 			if delErr := status.DeleteCondition(cond.Kind, o.facility, cond.ID.String()); delErr != nil {
 				le.WithError(delErr).Warn("deleting unlinked condition")
 			}

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -286,6 +286,7 @@ func parseEventUpdateFromKV(ctx context.Context, kve nats.KeyValueEntry, kind rc
 			State:       convState,
 			Status:      cs.Status,
 			UpdatedAt:   cs.UpdatedAt,
+			CreatedAt:   cs.CreatedAt,
 		},
 		Kind:         kind,
 		ControllerID: controllerID,
@@ -303,6 +304,7 @@ func failedUpdateEventFromCondition(cond *rctypes.Condition) *v1types.ConditionU
 			State:       rctypes.Failed,
 			Status:      failedByReconciler,
 			UpdatedAt:   time.Now(),
+			CreatedAt:   cond.CreatedAt,
 		},
 		Kind: cond.Kind,
 	}

--- a/internal/orchestrator/updates_test.go
+++ b/internal/orchestrator/updates_test.go
@@ -753,6 +753,7 @@ func TestFilterToReconcile(t *testing.T) {
 						ServerID:    sid1,
 						State:       rctypes.Failed,
 						Status:      failedByReconciler,
+						CreatedAt:   createdTS.Add(-rctypes.StaleThreshold - 2*time.Minute),
 					},
 					Kind: rctypes.FirmwareInstall,
 				},

--- a/internal/store/nats.go
+++ b/internal/store/nats.go
@@ -282,7 +282,7 @@ func (n *natsStore) Update(ctx context.Context, serverID uuid.UUID, updated *rct
 	le := n.log.WithFields(logrus.Fields{
 		"serverID":      serverID.String(),
 		"conditionKind": updated.Kind,
-		"conditionID":   updated.ID.String(),
+		"update.ID":     updated.ID.String(),
 	})
 
 	cr, err := n.getCurrentConditionRecord(otelCtx, serverID)
@@ -294,8 +294,8 @@ func (n *natsStore) Update(ctx context.Context, serverID uuid.UUID, updated *rct
 
 	// stupid games, stupid prizes sanity check
 	if cr.ID != updated.ID {
-		le.WithField("record.ID", cr.ID.String()).Warn("condition id mismatch")
-		return errors.Wrap(ErrRepository, "condition id mismatch")
+		le.WithField("current.ID", cr.ID.String()).Warn("condition id mismatch")
+		return errors.Wrap(ErrActiveCondition, "condition id mismatch")
 	}
 
 	// XXX: Having multiple conditions composed together into a single unit of work makes


### PR DESCRIPTION
#### What does this PR do

- Incorporates fixes from https://github.com/metal-toolbox/conditionorc/pull/242
- Ensure `CreatedAt` field is passed through into `ConditionUpdate`
- DB event write sets `CreatedAt` if not set, since this is a required field.
- Fixes incorrect active-condition create attempt
