### PR TITLE
Remove Create function from nats store

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -541,10 +541,6 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal-toolbox/fleetdb v1.19.3 h1:Dk7MVi5rS42a4OI46Ye/etg8R5hm1iajaI4U0k1GSec=
 github.com/metal-toolbox/fleetdb v1.19.3/go.mod h1:v9agAzF7BhBBjA4rY+H2eZzQaBTEXO4b/Qikn4jmA7A=
-github.com/metal-toolbox/rivets v1.3.1-0.20240819072158-b0e2d577ffb2 h1:oLVmapAbFYZjt+BMsLpkfSGEV9f+PZyS1Z0ZDOtzbJs=
-github.com/metal-toolbox/rivets v1.3.1-0.20240819072158-b0e2d577ffb2/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
-github.com/metal-toolbox/rivets v1.3.2-0.20240821095555-56f1bf4b1a29 h1:m8suYpZ7V3IHwiEUFmcjo1KD19+ir6iXmY1a9rQo7Nk=
-github.com/metal-toolbox/rivets v1.3.2-0.20240821095555-56f1bf4b1a29/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/metal-toolbox/rivets v1.3.2 h1:wazODpX94E2IbjuqEAmARl1r9TZE0NS1vBiGSpBW/tE=
 github.com/metal-toolbox/rivets v1.3.2/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=

--- a/internal/orchestrator/updates.go
+++ b/internal/orchestrator/updates.go
@@ -790,7 +790,7 @@ func (o *Orchestrator) reconcileActiveConditionRecords(ctx context.Context) {
 		if err != nil {
 			// create record if it doesn't exist
 			if errors.Is(err, store.ErrConditionNotFound) {
-				if errCreate := o.repository.CreateMultiple(ctx, cond.Target, o.facility, cond); errCreate != nil {
+				if errCreate := o.repository.Create(ctx, cond.Target, o.facility, cond); errCreate != nil {
 					le.WithError(errCreate).Warn("reconciler condition record create")
 				}
 

--- a/internal/orchestrator/updates_test.go
+++ b/internal/orchestrator/updates_test.go
@@ -325,7 +325,7 @@ func TestActiveConditionsToReconcile_Creates(t *testing.T) {
 
 			ctx := context.Background()
 			for _, cond := range tc.conditions {
-				err := o.repository.CreateMultiple(ctx, cond.Target, o.facility, cond)
+				err := o.repository.Create(ctx, cond.Target, o.facility, cond)
 				require.NoError(t, err)
 			}
 
@@ -379,7 +379,7 @@ func TestActiveConditionsToReconcile_Updates(t *testing.T) {
 	// active-conditions handle
 	acKV := newCleanActiveConditionsKV(t)
 
-	if err := o.repository.CreateMultiple(ctx, sid, o.facility, fwcond, invcond); err != nil {
+	if err := o.repository.Create(ctx, sid, o.facility, fwcond, invcond); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -50,10 +50,10 @@ type Repository interface {
 	// @serverID: required
 	GetActiveCondition(ctx context.Context, serverID uuid.UUID) (*rctypes.Condition, error)
 
-	// Create a condition record that encapsulates a unit of work encompassing multiple conditions
+	// Create a condition record that encapsulates a unit of work, which can encompass one or many conditions.
 	// If you create a condition record with 0 conditions, you don't actually create anything, but
 	// no error is returned.
-	CreateMultiple(ctx context.Context, serverID uuid.UUID, facilityCode string, conditions ...*rctypes.Condition) error
+	Create(ctx context.Context, serverID uuid.UUID, facilityCode string, conditions ...*rctypes.Condition) error
 
 	// Update a condition on a server
 	// @serverID: required

--- a/internal/store/mock_repository.go
+++ b/internal/store/mock_repository.go
@@ -25,8 +25,8 @@ func (_m *MockRepository) EXPECT() *MockRepository_Expecter {
 	return &MockRepository_Expecter{mock: &_m.Mock}
 }
 
-// CreateMultiple provides a mock function with given fields: ctx, serverID, facilityCode, conditions
-func (_m *MockRepository) CreateMultiple(ctx context.Context, serverID uuid.UUID, facilityCode string, conditions ...*condition.Condition) error {
+// Create provides a mock function with given fields: ctx, serverID, facilityCode, conditions
+func (_m *MockRepository) Create(ctx context.Context, serverID uuid.UUID, facilityCode string, conditions ...*condition.Condition) error {
 	_va := make([]interface{}, len(conditions))
 	for _i := range conditions {
 		_va[_i] = conditions[_i]
@@ -37,7 +37,7 @@ func (_m *MockRepository) CreateMultiple(ctx context.Context, serverID uuid.UUID
 	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CreateMultiple")
+		panic("no return value specified for Create")
 	}
 
 	var r0 error
@@ -50,22 +50,22 @@ func (_m *MockRepository) CreateMultiple(ctx context.Context, serverID uuid.UUID
 	return r0
 }
 
-// MockRepository_CreateMultiple_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateMultiple'
-type MockRepository_CreateMultiple_Call struct {
+// MockRepository_Create_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Create'
+type MockRepository_Create_Call struct {
 	*mock.Call
 }
 
-// CreateMultiple is a helper method to define mock.On call
+// Create is a helper method to define mock.On call
 //   - ctx context.Context
 //   - serverID uuid.UUID
 //   - facilityCode string
 //   - conditions ...*condition.Condition
-func (_e *MockRepository_Expecter) CreateMultiple(ctx interface{}, serverID interface{}, facilityCode interface{}, conditions ...interface{}) *MockRepository_CreateMultiple_Call {
-	return &MockRepository_CreateMultiple_Call{Call: _e.mock.On("CreateMultiple",
+func (_e *MockRepository_Expecter) Create(ctx interface{}, serverID interface{}, facilityCode interface{}, conditions ...interface{}) *MockRepository_Create_Call {
+	return &MockRepository_Create_Call{Call: _e.mock.On("Create",
 		append([]interface{}{ctx, serverID, facilityCode}, conditions...)...)}
 }
 
-func (_c *MockRepository_CreateMultiple_Call) Run(run func(ctx context.Context, serverID uuid.UUID, facilityCode string, conditions ...*condition.Condition)) *MockRepository_CreateMultiple_Call {
+func (_c *MockRepository_Create_Call) Run(run func(ctx context.Context, serverID uuid.UUID, facilityCode string, conditions ...*condition.Condition)) *MockRepository_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]*condition.Condition, len(args)-3)
 		for i, a := range args[3:] {
@@ -78,12 +78,12 @@ func (_c *MockRepository_CreateMultiple_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *MockRepository_CreateMultiple_Call) Return(_a0 error) *MockRepository_CreateMultiple_Call {
+func (_c *MockRepository_Create_Call) Return(_a0 error) *MockRepository_Create_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockRepository_CreateMultiple_Call) RunAndReturn(run func(context.Context, uuid.UUID, string, ...*condition.Condition) error) *MockRepository_CreateMultiple_Call {
+func (_c *MockRepository_Create_Call) RunAndReturn(run func(context.Context, uuid.UUID, string, ...*condition.Condition) error) *MockRepository_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/store/nats_test.go
+++ b/internal/store/nats_test.go
@@ -110,7 +110,7 @@ func TestCreateReadUpdate(t *testing.T) {
 	require.Nil(t, active)
 
 	// add a condition
-	err = store.CreateMultiple(context.TODO(), serverID, "fc-13", condition)
+	err = store.Create(context.TODO(), serverID, "fc-13", condition)
 	require.NoError(t, err)
 
 	active, err = store.GetActiveCondition(context.TODO(), serverID)
@@ -147,7 +147,7 @@ func TestCreateReadUpdate(t *testing.T) {
 }
 
 // Given a conditionRecord with multiple conditions, walk through some common
-// scenarios around CreateMultiple/Update/Get/GetActive
+// scenarios around Create/Update/Get/GetActive
 func TestMultipleConditionUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -161,20 +161,20 @@ func TestMultipleConditionUpdate(t *testing.T) {
 	t.Run("create multiple sanity checks", func(t *testing.T) {
 		serverID := uuid.New()
 
-		err := store.CreateMultiple(context.TODO(), serverID, facility)
+		err := store.Create(context.TODO(), serverID, facility)
 		require.NoError(t, err, "created multiple with nil work")
 
 		work := []*rctypes.Condition{
-			&rctypes.Condition{
+			{
 				Kind:  rctypes.Kind("first"),
 				State: rctypes.Pending,
 			},
 		}
 
-		err = store.CreateMultiple(context.TODO(), serverID, facility, work...)
+		err = store.Create(context.TODO(), serverID, facility, work...)
 		require.NoError(t, err, "created multiple on idle server with work")
 
-		err = store.CreateMultiple(context.TODO(), serverID, facility, work...)
+		err = store.Create(context.TODO(), serverID, facility, work...)
 		require.ErrorIs(t, err, ErrActiveCondition, "created multiple on busy server with work")
 
 	})
@@ -193,8 +193,8 @@ func TestMultipleConditionUpdate(t *testing.T) {
 			second,
 		}
 
-		err := store.CreateMultiple(context.TODO(), serverID, facility, work...)
-		require.NoError(t, err, "CreateMultiple")
+		err := store.Create(context.TODO(), serverID, facility, work...)
+		require.NoError(t, err, "Create")
 
 		active, err := store.GetActiveCondition(context.TODO(), serverID)
 		require.NoError(t, err, "GetActiveCondition I")
@@ -243,8 +243,8 @@ func TestMultipleConditionUpdate(t *testing.T) {
 			second,
 		}
 
-		err := store.CreateMultiple(context.TODO(), serverID, facility, work...)
-		require.NoError(t, err, "CreateMultiple")
+		err := store.Create(context.TODO(), serverID, facility, work...)
+		require.NoError(t, err, "Create")
 
 		active, err := store.GetActiveCondition(context.TODO(), serverID)
 		require.NoError(t, err, "GetActiveCondition I")

--- a/pkg/api/v1/conditions/client/client_test.go
+++ b/pkg/api/v1/conditions/client/client_test.go
@@ -229,7 +229,7 @@ func TestConditionCreate(t *testing.T) {
 				).Once()
 
 				r.On(
-					"CreateMultiple",
+					"Create",
 					mock.Anything,
 					serverID,
 					mock.Anything,
@@ -359,7 +359,7 @@ func TestFirmwareInstall(t *testing.T) {
 				FirmwareSetID: fwset.UUID,
 			},
 			mockStore: func(r *store.MockRepository) {
-				r.On("CreateMultiple", mock.Anything, serverID, "facility", mock.Anything, mock.Anything).
+				r.On("Create", mock.Anything, serverID, "facility", mock.Anything, mock.Anything).
 					Return(nil).Once()
 
 			},
@@ -384,7 +384,7 @@ func TestFirmwareInstall(t *testing.T) {
 				FirmwareSetID: fwset.UUID,
 			},
 			mockStore: func(r *store.MockRepository) {
-				r.On("CreateMultiple", mock.Anything, serverID, "facility", mock.Anything, mock.Anything).
+				r.On("Create", mock.Anything, serverID, "facility", mock.Anything, mock.Anything).
 					Return(nil).Once()
 			},
 			mockFleetDB: func(r *fleetdb.MockFleetDB) {
@@ -413,7 +413,7 @@ func TestFirmwareInstall(t *testing.T) {
 					Return(fwset, nil).Once()
 			},
 			mockStore: func(r *store.MockRepository) {
-				r.On("CreateMultiple", mock.Anything, serverID, "facility", mock.Anything, mock.Anything).
+				r.On("Create", mock.Anything, serverID, "facility", mock.Anything, mock.Anything).
 					Return(fmt.Errorf("%w:%s", store.ErrActiveCondition, "pound sand")).Once()
 			},
 			expectResponse: func() *v1types.ServerResponse {
@@ -520,7 +520,7 @@ func TestServerEnroll(t *testing.T) {
 			},
 			mockStore: func(r *store.MockRepository) {
 				// expect valid payload
-				r.On("CreateMultiple",
+				r.On("Create",
 					mock.Anything,
 					serverID,
 					mock.Anything,
@@ -664,7 +664,7 @@ func TestServerEnrollEmptyUUID(t *testing.T) {
 		Return(rollback, nil).
 		Once()
 
-	tester.repository.On("CreateMultiple",
+	tester.repository.On("Create",
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,

--- a/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
+++ b/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
@@ -99,8 +99,8 @@ func (r *Routes) validateFirmware(c *gin.Context) (int, *v1types.ServerResponse)
 
 	conds := firmwareValidationConditions(fvr)
 	// XXX: This is lifted from the firmwareInstall api code. Consider abstracting a utility method for
-	// CreateMultiple and publishCondition.
-	if err = r.repository.CreateMultiple(otelCtx, fvr.ServerID, facilityCode, conds.Conditions...); err != nil {
+	// Create and publishCondition.
+	if err = r.repository.Create(otelCtx, fvr.ServerID, facilityCode, conds.Conditions...); err != nil {
 		if errors.Is(err, store.ErrActiveCondition) {
 			return http.StatusConflict, &v1types.ServerResponse{
 				Message: err.Error(),

--- a/pkg/api/v1/conditions/routes/firmware_validation_handlers_test.go
+++ b/pkg/api/v1/conditions/routes/firmware_validation_handlers_test.go
@@ -72,9 +72,9 @@ func TestValidateFirmware(t *testing.T) {
 		require.NoError(t, err, "creating validation request")
 
 		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Twice()
-		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
 			Return(store.ErrActiveCondition).Once()
-		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
 			Return(errors.New("pound sand")).Once()
 
 		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(fvr))
@@ -109,7 +109,7 @@ func TestValidateFirmware(t *testing.T) {
 
 		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Once()
 
-		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
 			Return(nil).Once()
 		repo.On("Update", mock.Anything, srv.ID, mock.Anything).Return(nil).Once()
 
@@ -141,7 +141,7 @@ func TestValidateFirmware(t *testing.T) {
 
 		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Once()
 
-		repo.On("CreateMultiple", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
 			Return(nil).Once()
 
 		stream.On("Publish", mock.Anything, "fc13.servers.firmwareInstall", mock.Anything).Return(nil).Once()

--- a/pkg/api/v1/conditions/routes/handlers.go
+++ b/pkg/api/v1/conditions/routes/handlers.go
@@ -354,7 +354,7 @@ func (r *Routes) firmwareInstall(c *gin.Context) (int, *v1types.ServerResponse) 
 	}
 
 	serverConditions := r.firmwareInstallComposite(serverID, fwtp, fwset)
-	if err = r.repository.CreateMultiple(otelCtx, serverID, facilityCode, serverConditions.Conditions...); err != nil {
+	if err = r.repository.Create(otelCtx, serverID, facilityCode, serverConditions.Conditions...); err != nil {
 		if errors.Is(err, store.ErrActiveCondition) {
 			return http.StatusConflict, &v1types.ServerResponse{
 				Message: err.Error(),
@@ -479,7 +479,7 @@ func (r *Routes) firmwareInstallComposite(
 
 func (r *Routes) conditionCreate(otelCtx context.Context, newCondition *rctypes.Condition, serverID uuid.UUID, facilityCode string) (int, *v1types.ServerResponse) {
 	// Create the new condition
-	err := r.repository.CreateMultiple(otelCtx, serverID, facilityCode, newCondition)
+	err := r.repository.Create(otelCtx, serverID, facilityCode, newCondition)
 	if err != nil {
 		r.logger.WithError(err).Info("condition create failed")
 

--- a/pkg/api/v1/conditions/routes/handlers_test.go
+++ b/pkg/api/v1/conditions/routes/handlers_test.go
@@ -134,7 +134,7 @@ func TestAddServer(t *testing.T) {
 			// mock repository
 			mockStore: func(r *store.MockRepository) {
 				// create condition query
-				r.On("CreateMultiple", mock.Anything, mockServerID, mockFacilityCode, mock.Anything).
+				r.On("Create", mock.Anything, mockServerID, mockFacilityCode, mock.Anything).
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						c := args.Get(3).(*rctypes.Condition)
@@ -270,7 +270,7 @@ func TestAddServer(t *testing.T) {
 			// mock repository
 			mockStore: func(r *store.MockRepository) {
 				// create condition query
-				r.On("CreateMultiple", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				r.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						id := args.Get(1).(uuid.UUID)
@@ -603,7 +603,7 @@ func TestAddServerRollback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			rollbackCallCounter = 0
 			if tc.mockStoreCreateErr.calledTime > 0 {
-				repository.On("CreateMultiple", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				repository.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(tc.mockStoreCreateErr.err).
 					Times(tc.mockStoreCreateErr.calledTime)
 			}
@@ -746,7 +746,7 @@ func TestServerConditionCreate(t *testing.T) {
 				r.On("GetActiveCondition", mock.Anything, serverID).
 					Return(nil, nil).
 					Once()
-				r.On("CreateMultiple", mock.Anything, serverID, facilityCode, mock.IsType(&rctypes.Condition{})).
+				r.On("Create", mock.Anything, serverID, facilityCode, mock.IsType(&rctypes.Condition{})).
 					Run(func(args mock.Arguments) {
 						c := args.Get(3).(*rctypes.Condition)
 						assert.Equal(t, rctypes.ConditionStructVersion, c.Version, "condition version mismatch")
@@ -798,7 +798,7 @@ func TestServerConditionCreate(t *testing.T) {
 					Return(nil, nil).
 					Once()
 
-				create := r.On("CreateMultiple", mock.Anything, serverID, facilityCode, mock.IsType(&rctypes.Condition{})).
+				create := r.On("Create", mock.Anything, serverID, facilityCode, mock.IsType(&rctypes.Condition{})).
 					Run(func(args mock.Arguments) {
 						c := args.Get(3).(*rctypes.Condition)
 						expect := &rctypes.Fault{Panic: true, DelayDuration: "10s", FailAt: "foobar"}
@@ -881,7 +881,7 @@ func TestServerConditionCreate(t *testing.T) {
 				r.On("GetActiveCondition", mock.Anything, serverID).
 					Return(nil, nil).
 					Once()
-				r.On("CreateMultiple", mock.Anything, serverID, facilityCode, mock.IsType(&rctypes.Condition{})).
+				r.On("Create", mock.Anything, serverID, facilityCode, mock.IsType(&rctypes.Condition{})).
 					Run(func(args mock.Arguments) {
 						c := args.Get(3).(*rctypes.Condition)
 						assert.Equal(t, rctypes.ConditionStructVersion, c.Version, "condition version mismatch")


### PR DESCRIPTION
#### What does this PR do

- Remove "Create" function from nats store
- Rename "CreateMultiple" to "Create", since the original Create is removed.

#### Why

"Create" is unused, vestigial code, and provides no additional functionality from "CreateMultiple"