### PR TITLE
add the firmware validation condition

### DIFF
--- a/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
+++ b/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
@@ -37,6 +37,12 @@ func firmwareValidationConditions(fvr FirmwareValidationRequest) *rctypes.Server
 		ResetBMCBeforeInstall: true,
 	}
 
+	validationParams := &rctypes.ServerControlTaskParameters{
+		AssetID:                 fvr.ServerID,
+		Action:                  rctypes.ValidateFirmware,
+		ValidateFirmwareTimeout: 30 * time.Minute,
+	}
+
 	return &rctypes.ServerConditions{
 		ServerID: fvr.ServerID,
 		Conditions: []*rctypes.Condition{
@@ -54,7 +60,13 @@ func firmwareValidationConditions(fvr FirmwareValidationRequest) *rctypes.Server
 				State:      rctypes.Pending,
 				CreatedAt:  createTime,
 			},
-			// TODO: Need a firmware validation task, but first things first!
+			{
+				Kind:       rctypes.ServerControl,
+				Version:    rctypes.ConditionStructVersion,
+				Parameters: validationParams.MustJSON(),
+				State:      rctypes.Pending,
+				CreatedAt:  createTime,
+			},
 		},
 	}
 }
@@ -129,7 +141,7 @@ func (r *Routes) validateFirmware(c *gin.Context) (int, *v1types.ServerResponse)
 
 	metrics.ConditionQueued.With(
 		// XXX: define a Kind for firmwareValidation
-		prometheus.Labels{"conditionKind": string(rctypes.FirmwareInstall)},
+		prometheus.Labels{"conditionKind": string(rctypes.ValidateFirmware)},
 	).Inc()
 
 	return http.StatusOK, &v1types.ServerResponse{

--- a/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
+++ b/pkg/api/v1/conditions/routes/firmware_validation_handlers.go
@@ -41,6 +41,7 @@ func firmwareValidationConditions(fvr FirmwareValidationRequest) *rctypes.Server
 		AssetID:                 fvr.ServerID,
 		Action:                  rctypes.ValidateFirmware,
 		ValidateFirmwareTimeout: 30 * time.Minute,
+		ValidateFirmwareID:      fvr.FirmwareSetID,
 	}
 
 	return &rctypes.ServerConditions{

--- a/pkg/api/v1/conditions/routes/firmware_validation_handlers_test.go
+++ b/pkg/api/v1/conditions/routes/firmware_validation_handlers_test.go
@@ -72,9 +72,9 @@ func TestValidateFirmware(t *testing.T) {
 		require.NoError(t, err, "creating validation request")
 
 		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Twice()
-		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything, mock.Anything).
 			Return(store.ErrActiveCondition).Once()
-		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything, mock.Anything).
 			Return(errors.New("pound sand")).Once()
 
 		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fwValidationUrl, bytes.NewReader(fvr))
@@ -109,7 +109,7 @@ func TestValidateFirmware(t *testing.T) {
 
 		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Once()
 
-		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).Once()
 		repo.On("Update", mock.Anything, srv.ID, mock.Anything).Return(nil).Once()
 
@@ -141,7 +141,7 @@ func TestValidateFirmware(t *testing.T) {
 
 		fleetdb.On("GetServer", mock.Anything, mock.Anything).Return(srv, nil).Once()
 
-		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything).
+		repo.On("Create", mock.Anything, mock.Anything, "fc13", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).Once()
 
 		stream.On("Publish", mock.Anything, "fc13.servers.firmwareInstall", mock.Anything).Return(nil).Once()


### PR DESCRIPTION
Previous work added an endpoint in Condition API to queue work for firmware validation but did not add an actual condition to trigger a controller to perform the validation step, because the controller support was not implemented. Now that this support exists, it is time to integrate the actual firmware validation task.

