### PR TITLE
api/conditions/handlers: Condition to include TraceID, SpanID, Client ID attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/metal-toolbox/fleetdb v1.19.3
-	github.com/metal-toolbox/rivets v1.3.3
+	github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25
 	github.com/nats-io/nats-server/v2 v2.10.12
 	github.com/nats-io/nats.go v1.36.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/metal-toolbox/fleetdb v1.19.3
-	github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25
+	github.com/metal-toolbox/rivets v1.3.6
 	github.com/nats-io/nats-server/v2 v2.10.12
 	github.com/nats-io/nats.go v1.36.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -549,6 +549,8 @@ github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0 h1:IJlBEwzi
 github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25 h1:z6gipdqU9pkHDHeNb0hmwtR3+zOpaWDIuDLDVHALnk8=
 github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.6 h1:iw1KlhNcK8ZIHnBGwKeqtYInyN/prhiblb6qE+FhzH0=
+github.com/metal-toolbox/rivets v1.3.6/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/go.sum
+++ b/go.sum
@@ -545,6 +545,10 @@ github.com/metal-toolbox/rivets v1.3.2 h1:wazODpX94E2IbjuqEAmARl1r9TZE0NS1vBiGSp
 github.com/metal-toolbox/rivets v1.3.2/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/metal-toolbox/rivets v1.3.3 h1:bHd2HRh/uc3zb2bughpuidW2lUQOXrFRRDWBWwqMQWw=
 github.com/metal-toolbox/rivets v1.3.3/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0 h1:IJlBEwziIPEfhjZdwIFUYzPPS7xlWlxznPXqmrQ67/0=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25 h1:z6gipdqU9pkHDHeNb0hmwtR3+zOpaWDIuDLDVHALnk8=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/pkg/api/v1/conditions/routes/handlers_test.go
+++ b/pkg/api/v1/conditions/routes/handlers_test.go
@@ -1203,7 +1203,7 @@ func TestFirmwareInstallComposite(t *testing.T) {
 				os.Setenv("CONDITION_API_FEATURE_INBAND_FIRMWARE", "true")
 			}
 
-			got := r.firmwareInstallComposite(serverID, fwtp, tc.fwset)
+			got := r.firmwareInstallComposite(context.Background(), serverID, "foobar", fwtp, tc.fwset)
 			assert.Equal(t, tc.expectConditions, len(got.Conditions))
 			for _, cond := range got.Conditions {
 				assert.NotEmpty(t, cond.Kind)


### PR DESCRIPTION
#### What does this PR do

This enables tracing and linking Conditions executed by Controllers and
managed by the Orchestrator. So far, Span, TraceIDs were included in the
the NATS message header when a Condition gets published to the
Jetstream. 

Since not all Conditions are published onto the Jetstream (firmwareInstallInband) and 
we'd like to ensure the traces are linked. The TraceID, SpanID is included in the Condition payload itself and the NATS message  header can be deprecated.

 The Client ID information is included to ensure we can identify the
 client that queued the request.

![Screenshot 2024-09-02 at 16 32 48](https://github.com/user-attachments/assets/b63f8041-3066-4e76-b028-3afb2598223c)

NOTE: Pin on rivets tag before merge.