### PR TITLE
api/conditions: fixes incorrect firmware composition for oob installs

### DIFF
--- a/pkg/api/v1/conditions/routes/handlers.go
+++ b/pkg/api/v1/conditions/routes/handlers.go
@@ -480,8 +480,10 @@ func (r *Routes) firmwareInstallComposite(
 		Conditions: []*rctypes.Condition{},
 	}
 
-	// under feature flag until this is confirmed to be working as expected
-	// - if set - include require inband - if firmwares shares that requirement
+	// Under feature flag until this is confirmed to be working as expected
+	//
+	// with this feature flag set, the pxeBoot, inband conditions are published,
+	// if the component firmware indicates it should be installed inband
 	if os.Getenv("CONDITION_API_FEATURE_INBAND_FIRMWARE") != "" {
 		for idx := range fwset.ComponentFirmware {
 			if booleanIsTrue(fwset.ComponentFirmware[idx].InstallInband) {

--- a/pkg/api/v1/conditions/routes/handlers.go
+++ b/pkg/api/v1/conditions/routes/handlers.go
@@ -481,20 +481,17 @@ func (r *Routes) firmwareInstallComposite(
 	}
 
 	// under feature flag until this is confirmed to be working as expected
+	// - if set - include require inband - if firmwares shares that requirement
 	if os.Getenv("CONDITION_API_FEATURE_INBAND_FIRMWARE") != "" {
-		var requireInband bool
 		for idx := range fwset.ComponentFirmware {
 			if booleanIsTrue(fwset.ComponentFirmware[idx].InstallInband) {
-				requireInband = true
+				sc.Conditions = append(sc.Conditions, pxeBoot, inband, oob, inv)
+				return sc
 			}
 		}
-
-		if requireInband {
-			sc.Conditions = append(sc.Conditions, pxeBoot, inband, oob, inv)
-		}
-	} else {
-		sc.Conditions = append(sc.Conditions, oob, inv)
 	}
+
+	sc.Conditions = append(sc.Conditions, oob, inv)
 
 	return sc
 }


### PR DESCRIPTION
#### What does this PR do
The CONDITION_API_FEATURE_INBAND_FIRMWARE env variable when enabled would result in an empty list of Conditions if all the firmware in the set are to be installed out of band. This fixes the issue and adds tests.


