### PR TITLE
Add some additional error messaging around biosControl

### DIFF
--- a/.github/workflows/push-pr-lint.yaml
+++ b/.github/workflows/push-pr-lint.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           args: --config .golangci.yml --timeout 2m
-          version: v1.61.0
+          version: v1.62.2
           skip-cache: true
 
       - name: Test

--- a/.github/workflows/push-pr-lint.yaml
+++ b/.github/workflows/push-pr-lint.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           args: --config .golangci.yml --timeout 2m
-          version: v1.62.2
+          version: v1.61.0
           skip-cache: true
 
       - name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,7 @@
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: v1.57.1 # use the fixed version to not introduce new linters unexpectedly
-
 linters-settings:
   govet:
-    auto-fix: true
-    shadow: true
     settings:
       printf:
         funcs:
@@ -14,8 +9,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  revive:
-    min-confidence: 0
   gocyclo:
     min-complexity: 15
   dupl:
@@ -23,15 +16,8 @@ linters-settings:
   goconst:
     min-len: 2
     min-occurrences: 2
-  depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
-      - github.com/sirupsen/logrus
   misspell:
     locale: US
-    auto-fix: true
   lll:
     line-length: 140
   goimports:
@@ -45,8 +31,6 @@ linters-settings:
       - wrapperFunc
   gofumpt:
     extra-rules: true
-  whitespace:
-    auto-fix: true
 
 linters:
   enable:
@@ -118,4 +102,3 @@ issues:
     - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
     # EXC0010 gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
     - Potential file inclusion via variable
-exclude-use-default: false

--- a/pkg/api/v1/conditions/routes/handlers.go
+++ b/pkg/api/v1/conditions/routes/handlers.go
@@ -553,15 +553,15 @@ func (r *Routes) biosControl(c *gin.Context) (int, *v1types.ServerResponse) {
 
 	var bctp rctypes.BiosControlTaskParameters
 	if err = c.ShouldBindJSON(&bctp); err != nil {
-		r.logger.WithError(err).Warn("unmarshal biosControl payload")
-
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			body = []byte("unable to read request body")
 		}
 
+		r.logger.WithError(err).Warn("unmarshal biosControl payload\nbody: " + string(body))
+
 		return http.StatusBadRequest, &v1types.ServerResponse{
-			Message: "invalid biosControl payload: " + err.Error() + "\n body: " + string(body),
+			Message: "invalid biosControl payload: " + err.Error() + "\nbody: " + string(body),
 		}
 	}
 

--- a/pkg/api/v1/conditions/routes/handlers.go
+++ b/pkg/api/v1/conditions/routes/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -554,8 +555,13 @@ func (r *Routes) biosControl(c *gin.Context) (int, *v1types.ServerResponse) {
 	if err = c.ShouldBindJSON(&bctp); err != nil {
 		r.logger.WithError(err).Warn("unmarshal biosControl payload")
 
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			body = []byte("unable to read request body")
+		}
+
 		return http.StatusBadRequest, &v1types.ServerResponse{
-			Message: "invalid biosControl payload: " + err.Error(),
+			Message: "invalid biosControl payload: " + err.Error() + "\n body: " + string(body),
 		}
 	}
 


### PR DESCRIPTION
#### What does this PR do

This PR adds the failed request body to the error message when there is a failure to parse the request body sent to biosControl. This is necessary because the current error message does not provide what the incorrect body looks like, just that it wasn't able to parse it. When working with requests that may have been mangled by an intermediate service, it helps to have this as part of the error response for debugging purposes.