### PR TITLE
Fixed nil pointer dereference in biosControl

### DIFF
--- a/pkg/api/v1/conditions/routes/handlers.go
+++ b/pkg/api/v1/conditions/routes/handlers.go
@@ -552,14 +552,16 @@ func (r *Routes) biosControl(c *gin.Context) (int, *v1types.ServerResponse) {
 	}
 
 	var bctp rctypes.BiosControlTaskParameters
-	if err = c.ShouldBindJSON(&bctp); err != nil {
-		body, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			body = []byte("unable to read request body")
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		r.logger.WithError(err).Warn("unable to read request body")
+		return http.StatusBadRequest, &v1types.ServerResponse{
+			Message: "unable to read request body: " + err.Error(),
 		}
+	}
 
+	if err = json.Unmarshal(body, &bctp); err != nil {
 		r.logger.WithError(err).Warn("unmarshal biosControl payload\nbody: " + string(body))
-
 		return http.StatusBadRequest, &v1types.ServerResponse{
 			Message: "invalid biosControl payload: " + err.Error() + "\nbody: " + string(body),
 		}


### PR DESCRIPTION
#### What does this PR do

Fixes a nil pointer dereference introduced in error conditions when performing bioscontrol actions. I forgot how go io.Readers work so I was attempting to read an io.Reader after it already had been read, thus resulting in the nil pointer error. This reworks the logic of that code so that the request body is read out and then stored to be used in the logging and unmarshalled separately.